### PR TITLE
feat: Multi-Oracle Quorum 

### DIFF
--- a/backend/indexer/migrations/002_create_quorum_tables.sql
+++ b/backend/indexer/migrations/002_create_quorum_tables.sql
@@ -1,0 +1,23 @@
+-- Migration: Create Quorum Tables
+
+-- Table for global quorum settings
+CREATE TABLE IF NOT EXISTS quorum_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1), -- Only one row for global settings
+    threshold INTEGER NOT NULL DEFAULT 1
+);
+
+-- Insert default threshold
+INSERT OR IGNORE INTO quorum_settings (id, threshold) VALUES (1, 1);
+
+-- Table for tracking oracle votes for projects
+CREATE TABLE IF NOT EXISTS oracle_votes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id TEXT NOT NULL,
+    oracle_address TEXT NOT NULL,
+    proof_hash TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(project_id, oracle_address) -- Ensure idempotence per oracle per project
+);
+
+-- Index for counting votes per project and proof hash
+CREATE INDEX IF NOT EXISTS idx_oracle_votes_project_hash ON oracle_votes(project_id, proof_hash);

--- a/backend/indexer/src/api.rs
+++ b/backend/indexer/src/api.rs
@@ -8,7 +8,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
 use crate::db;
@@ -45,6 +45,23 @@ pub struct HealthResponse {
 #[derive(Serialize)]
 pub struct ErrorResponse {
     pub error: String,
+}
+
+#[derive(Deserialize)]
+pub struct VoteRequest {
+    pub oracle: String,
+    pub proof_hash: String,
+}
+
+#[derive(Deserialize)]
+pub struct ThresholdRequest {
+    pub threshold: u32,
+}
+
+#[derive(Serialize)]
+pub struct VoteResponse {
+    pub accepted: bool,
+    pub message: String,
 }
 
 // ─────────────────────────────────────────────────────────
@@ -102,6 +119,89 @@ pub async fn get_all_events(State(state): State<Arc<ApiState>>) -> impl IntoResp
             )
                 .into_response()
         }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(ErrorResponse {
+                error: e.to_string()
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /admin/quorum`
+///
+/// Updates the global quorum threshold.
+pub async fn set_quorum_threshold(
+    State(state): State<Arc<ApiState>>,
+    Json(payload): Json<ThresholdRequest>,
+) -> impl IntoResponse {
+    match db::set_quorum_threshold(&state.pool, payload.threshold).await {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "status": "updated" })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(ErrorResponse {
+                error: e.to_string()
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /projects/:id/vote`
+///
+/// Submits an oracle vote for a project.
+pub async fn submit_vote(
+    State(state): State<Arc<ApiState>>,
+    Path(project_id): Path<String>,
+    Json(payload): Json<VoteRequest>,
+) -> impl IntoResponse {
+    match db::record_vote(
+        &state.pool,
+        &project_id,
+        &payload.oracle,
+        &payload.proof_hash,
+    )
+    .await
+    {
+        Ok(accepted) => {
+            let (status, message) = if accepted {
+                (StatusCode::CREATED, "Vote recorded")
+            } else {
+                (StatusCode::OK, "Duplicate vote ignored")
+            };
+            (
+                status,
+                Json(VoteResponse {
+                    accepted,
+                    message: message.to_string(),
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(ErrorResponse {
+                error: e.to_string()
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /projects/:id/quorum`
+///
+/// Returns current quorum status for a project.
+pub async fn get_project_quorum(
+    State(state): State<Arc<ApiState>>,
+    Path(project_id): Path<String>,
+) -> impl IntoResponse {
+    match db::get_quorum_status(&state.pool, &project_id).await {
+        Ok(status) => (StatusCode::OK, Json(status)).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!(ErrorResponse {

--- a/backend/indexer/src/db.rs
+++ b/backend/indexer/src/db.rs
@@ -1,5 +1,6 @@
 //! Database layer — migrations, queries, and cursor management.
 
+use serde::Serialize;
 use sqlx::{sqlite::SqlitePoolOptions, SqlitePool};
 use tracing::info;
 
@@ -132,4 +133,179 @@ pub async fn get_all_events(pool: &SqlitePool) -> Result<Vec<EventRecord>> {
     .fetch_all(pool)
     .await?;
     Ok(rows)
+}
+
+// ─────────────────────────────────────────────────────────
+// Quorum management
+// ─────────────────────────────────────────────────────────
+
+/// Get the global quorum threshold for proof verification.
+pub async fn get_quorum_threshold(pool: &SqlitePool) -> Result<u32> {
+    let row: Option<(i32,)> = sqlx::query_as("SELECT threshold FROM quorum_settings WHERE id = 1")
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.map(|(v,)| v as u32).unwrap_or(1))
+}
+
+/// Update the global quorum threshold.
+pub async fn set_quorum_threshold(pool: &SqlitePool, threshold: u32) -> Result<()> {
+    sqlx::query("UPDATE quorum_settings SET threshold = ?1 WHERE id = 1")
+        .bind(threshold as i32)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Record an oracle vote for a specific project and proof hash.
+pub async fn record_vote(
+    pool: &SqlitePool,
+    project_id: &str,
+    oracle: &str,
+    hash: &str,
+) -> Result<bool> {
+    let res = sqlx::query(
+        "INSERT OR IGNORE INTO oracle_votes (project_id, oracle_address, proof_hash) VALUES (?1, ?2, ?3)",
+    )
+    .bind(project_id)
+    .bind(oracle)
+    .bind(hash)
+    .execute(pool)
+    .await?;
+
+    Ok(res.rows_affected() > 0)
+}
+
+#[derive(Serialize)]
+pub struct QuorumStatus {
+    pub project_id: String,
+    pub threshold: u32,
+    pub votes: Vec<VoteInfo>,
+    pub consensus_reached: bool,
+}
+
+#[derive(Serialize)]
+pub struct VoteInfo {
+    pub proof_hash: String,
+    pub count: u32,
+}
+
+/// Fetch the current quorum status for a project.
+pub async fn get_quorum_status(pool: &SqlitePool, project_id: &str) -> Result<QuorumStatus> {
+    let threshold = get_quorum_threshold(pool).await?;
+
+    // Query to count matching votes per hash for the given project
+    let votes = sqlx::query_as::<_, (String, i32)>(
+        "SELECT proof_hash, COUNT(*) as count FROM oracle_votes WHERE project_id = ?1 GROUP BY proof_hash",
+    )
+    .bind(project_id)
+    .fetch_all(pool)
+    .await?;
+
+    let vote_info: Vec<VoteInfo> = votes
+        .into_iter()
+        .map(|(proof_hash, count)| VoteInfo {
+            proof_hash,
+            count: count as u32,
+        })
+        .collect();
+
+    let consensus_reached = vote_info.iter().any(|v| v.count >= threshold);
+
+    Ok(QuorumStatus {
+        project_id: project_id.to_string(),
+        threshold,
+        votes: vote_info,
+        consensus_reached,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_test_db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // Run migrations manually from the migrations folder
+        // For simplicity in unit tests, we can just run the specific DDL
+        sqlx::query(
+            "CREATE TABLE quorum_settings (id INTEGER PRIMARY KEY CHECK (id = 1), threshold INTEGER NOT NULL DEFAULT 1);",
+        ).execute(&pool).await.unwrap();
+        sqlx::query("INSERT INTO quorum_settings (id, threshold) VALUES (1, 1);")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE oracle_votes (id INTEGER PRIMARY KEY AUTOINCREMENT, project_id TEXT NOT NULL, oracle_address TEXT NOT NULL, proof_hash TEXT NOT NULL, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, UNIQUE(project_id, oracle_address));",
+        ).execute(&pool).await.unwrap();
+
+        pool
+    }
+
+    #[tokio::test]
+    async fn test_quorum_threshold() {
+        let pool = setup_test_db().await;
+
+        // Default should be 1
+        assert_eq!(get_quorum_threshold(&pool).await.unwrap(), 1);
+
+        // Update to 3
+        set_quorum_threshold(&pool, 3).await.unwrap();
+        assert_eq!(get_quorum_threshold(&pool).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_voting_and_consensus() {
+        let pool = setup_test_db().await;
+        let project_id = "proj_123";
+        let hash_a = "hash_aaaa";
+        let hash_b = "hash_bbbb";
+
+        set_quorum_threshold(&pool, 2).await.unwrap();
+
+        // Oracle 1 votes for hash A
+        let accepted = record_vote(&pool, project_id, "oracle_1", hash_a)
+            .await
+            .unwrap();
+        assert!(accepted);
+
+        let status = get_quorum_status(&pool, project_id).await.unwrap();
+        assert_eq!(status.threshold, 2);
+        assert_eq!(status.votes.len(), 1);
+        assert_eq!(status.votes[0].count, 1);
+        assert!(!status.consensus_reached);
+
+        // Oracle 1 votes again (duplicate)
+        let accepted = record_vote(&pool, project_id, "oracle_1", hash_a)
+            .await
+            .unwrap();
+        assert!(!accepted);
+
+        // Oracle 2 votes for hash B (different hash)
+        record_vote(&pool, project_id, "oracle_2", hash_b)
+            .await
+            .unwrap();
+        let status = get_quorum_status(&pool, project_id).await.unwrap();
+        assert_eq!(status.votes.len(), 2);
+        assert!(!status.consensus_reached);
+
+        // Oracle 3 votes for hash A -> Consensus reached
+        record_vote(&pool, project_id, "oracle_3", hash_a)
+            .await
+            .unwrap();
+        let status = get_quorum_status(&pool, project_id).await.unwrap();
+        assert!(status.consensus_reached);
+        assert_eq!(
+            status
+                .votes
+                .iter()
+                .find(|v| v.proof_hash == hash_a)
+                .unwrap()
+                .count,
+            2
+        );
+    }
 }

--- a/backend/indexer/src/main.rs
+++ b/backend/indexer/src/main.rs
@@ -14,7 +14,10 @@ mod rpc;
 
 use std::sync::Arc;
 
-use axum::{routing::get, Router};
+use axum::{
+    routing::{get, post},
+    Router,
+};
 use reqwest::Client;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -60,6 +63,9 @@ async fn main() -> anyhow::Result<()> {
         .route("/health", get(api::health))
         .route("/events", get(api::get_all_events))
         .route("/projects/:id/events", get(api::get_project_events))
+        .route("/admin/quorum", post(api::set_quorum_threshold))
+        .route("/projects/:id/vote", post(api::submit_vote))
+        .route("/projects/:id/quorum", get(api::get_project_quorum))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(api_state);


### PR DESCRIPTION
Implementation of the Multi-Oracle Quorum in the PIFP indexer.

Voting API: Oracles can now submit proof hashes via POST /projects/:id/vote.
Quorum Tracking: The indexer tracks votes and determines consensus based on a global threshold (POST /admin/quorum to configure).
Status Reporting: GET /projects/:id/quorum provides a detailed breakdown of votes and whether consensus has been reached.
Verified: Comprehensive unit tests added to db.rs confirm the logic for threshold management, duplicate vote prevention, and consensus detection.
All tests passed and code is clean.

closes #59 