### PR TITLE
feat(contract): implement wasm-based contract upgradeability

### DIFF
--- a/contracts/pifp_protocol/src/events.rs
+++ b/contracts/pifp_protocol/src/events.rs
@@ -3,6 +3,13 @@
 use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
 use crate::types::ProtocolConfig;
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractUpgraded {
+    pub new_wasm_hash: BytesN<32>,
+    pub upgraded_by: Address,
+}
+
 const PROJECT_CREATED: Symbol = symbol_short!("created");
 const FUNDS_RELEASED: Symbol = symbol_short!("released");
 const MILESTONE_VERIFIED: Symbol = symbol_short!("m_verify");
@@ -402,4 +409,9 @@ pub fn emit_milestone_verified(
 ) {
     let topics = (MILESTONE_VERIFIED, project_id, milestone_index);
     env.events().publish(topics, bps);
+}
+
+pub fn emit_contract_upgraded(env: &Env, new_wasm_hash: BytesN<32>, upgraded_by: Address) {
+    let topics = (symbol_short!("upgraded"),);
+    env.events().publish(topics, ContractUpgraded { new_wasm_hash, upgraded_by });
 }

--- a/contracts/pifp_protocol/src/lib.rs
+++ b/contracts/pifp_protocol/src/lib.rs
@@ -79,7 +79,7 @@ mod test_reentrancy;
 
 use crate::types::ProjectStatus;
 pub use errors::Error;
-pub use events::emit_funds_released;
+pub use events::{emit_contract_upgraded, emit_funds_released};
 pub use rbac::Role;
 use storage::{
     clear_oracle_agreement, drain_token_balance, get_all_balances, get_and_increment_project_id,
@@ -150,6 +150,13 @@ impl PifpProtocol {
 
     pub fn is_paused(env: Env) -> bool {
         storage::is_paused(&env)
+    }
+
+    pub fn upgrade(env: Env, caller: Address, new_wasm_hash: BytesN<32>) {
+        caller.require_auth();
+        rbac::require_role(&env, &caller, &Role::SuperAdmin);
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        events::emit_contract_upgraded(&env, new_wasm_hash, caller);
     }
 
     // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #133 
 feat(contract): Implement WASM-Based Contract Upgradeability                                                                                            
                                                                                                                                                                                                                                                                                        ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  What changed                                                                                                                                            
                                                                                                                                                          
  Added an upgrade() function to the PifpProtocol contract that allows in-place WASM logic replacement without migrating on-chain state.                  
                                                                                                                                                          
  `contracts/pifp_protocol/src/lib.rs`                                                                                                                    
                                                                                                                                                          
  - Added upgrade(env, caller, new_wasm_hash) in the Emergency Control section                                                                            
  - Calls env.deployer().update_current_contract_wasm() to swap contract logic atomically                                                                 
                                                                                                                                                          
  `contracts/pifp_protocol/src/events.rs`                                                                                                                 
                                                                                                                                                          
  - Added ContractUpgraded event struct (new_wasm_hash, upgraded_by)                                                                                      
  - Added emit_contract_upgraded() for off-chain indexer auditability                                                                                     
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  Security                                                                                                                                                
                                                                                                                                                          
  - caller.require_auth() — wallet signature required                                                                                                     
  - rbac::require_role(..., Role::SuperAdmin) — strictly gated to SuperAdmin, consistent with other privileged operations like update_protocol_config     
  - No other role (Admin, Oracle, ProjectManager) can trigger an upgrade                                                                                  
                                                                                                                                                          
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                                                                          
  How to test                                                                                                                                             
                                                                                                                                                          
  cargo test --manifest-path contracts/pifp_protocol/Cargo.toml                                                                                           
                                                                                                                                                          
  To manually verify the upgrade path, deploy a modified WASM, capture its hash, and call upgrade() from the SuperAdmin address.                          
                                 


- Add upgrade() function gated to SuperAdmin only- 
- Use env.deployer().update_current_contract_wasm() for in-place logic upgrade without state migration
- Emit ContractUpgraded event for off-chain indexer auditability