### PR TITLE
feat(api): implement pagination for donor list endpoint

### DIFF
--- a/backend/indexer/README.md
+++ b/backend/indexer/README.md
@@ -81,6 +81,7 @@ In parallel to the background indexing daemon, an Axum web server runs to expose
 - `GET /health` : Returns server operational status and application version.
 - `GET /events` : List all indexed events across the entire protocol.
 - `GET /projects/:id/events` : Query historical events specifically generated for `project_id`.
+- `GET /projects/:id/donors?limit=20&offset=0` : Get paginated list of donors for a specific project, sorted by total donated amount.
 - `GET /projects/top?limit=10` : Top funded projects ranked by indexed `project_funded` events (cached when Redis is configured).
 - `GET /projects/active/count` : Current active projects count inferred from latest status events (`project_active`, `project_verified`, `project_expired`, `project_cancelled`) (cached when Redis is configured).
 
@@ -88,6 +89,37 @@ In parallel to the background indexing daemon, an Axum web server runs to expose
 - `POST /admin/quorum` : Update the global quorum threshold (expects a `{ threshold: u32 }` JSON payload).
 - `POST /projects/:id/vote` : Submit an oracle vote (expects a `{ oracle: string, proof_hash: string }` JSON payload).
 - `GET /projects/:id/quorum` : Returns the active vote count vs existing threshold for the given project.
+
+### Donors Endpoint Details
+
+The `GET /projects/:id/donors` endpoint provides paginated access to donor information for projects with potentially thousands of participants.
+
+**Query Parameters:**
+- `limit` (optional): Number of donors per page (default: 20, max: 100)
+- `offset` (optional): Number of donors to skip (default: 0)
+
+**Response Format:**
+```json
+{
+  "project_id": "project_123",
+  "total_donors": 1234,
+  "donors": [
+    {
+      "address": "donor_address_1",
+      "total_donated": "5000",
+      "donation_count": 3,
+      "first_donation_ledger": 12345,
+      "last_donation_ledger": 12567,
+      "first_donation_timestamp": 1640995200,
+      "last_donation_timestamp": 1641081600
+    }
+  ]
+}
+```
+
+**Sorting:** Donors are sorted by total donated amount (descending), then by first donation timestamp (ascending) for consistent pagination.
+
+**Performance:** The endpoint uses efficient SQL aggregation queries and supports proper pagination for projects with thousands of donors.
 
 **Webhook Endpoints:**
 - `POST /webhooks` : Register webhook URL + event subscriptions + secret (`{ "url": "...", "secret": "...", "event_types": ["project_active"] }`).

--- a/backend/indexer/examples/test_donors_endpoint.sh
+++ b/backend/indexer/examples/test_donors_endpoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Test script for the new donors endpoint
+# Usage: ./test_donors_endpoint.sh [base_url] [project_id]
+
+BASE_URL=${1:-"http://localhost:8080"}
+PROJECT_ID=${2:-"test_project"}
+
+echo "Testing Donors API Endpoint"
+echo "============================"
+echo "Base URL: $BASE_URL"
+echo "Project ID: $PROJECT_ID"
+echo ""
+
+# Test 1: Get first page of donors
+echo "Test 1: Get first page of donors (default limit=20, offset=0)"
+curl -s "$BASE_URL/projects/$PROJECT_ID/donors" | jq '.'
+echo ""
+
+# Test 2: Get donors with custom pagination
+echo "Test 2: Get donors with limit=5, offset=0"
+curl -s "$BASE_URL/projects/$PROJECT_ID/donors?limit=5&offset=0" | jq '.'
+echo ""
+
+# Test 3: Get second page
+echo "Test 3: Get second page with limit=5, offset=5"
+curl -s "$BASE_URL/projects/$PROJECT_ID/donors?limit=5&offset=5" | jq '.'
+echo ""
+
+# Test 4: Test with large limit (should be clamped to 100)
+echo "Test 4: Test with large limit=1000 (should be clamped to 100)"
+curl -s "$BASE_URL/projects/$PROJECT_ID/donors?limit=1000" | jq '.donors | length'
+echo ""
+
+# Test 5: Test with non-existent project
+echo "Test 5: Test with non-existent project"
+curl -s "$BASE_URL/projects/non_existent_project/donors" | jq '.'
+echo ""
+
+echo "Testing complete!"

--- a/backend/indexer/src/api.rs
+++ b/backend/indexer/src/api.rs
@@ -76,6 +76,19 @@ pub struct HistoryQuery {
     pub offset: Option<i64>,
 }
 
+#[derive(Deserialize)]
+pub struct DonorsQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Serialize)]
+pub struct DonorsResponse {
+    pub project_id: String,
+    pub total_donors: i64,
+    pub donors: Vec<db::DonorRecord>,
+}
+
 #[derive(Serialize)]
 pub struct ProjectsResponse {
     pub count: usize,
@@ -182,6 +195,46 @@ pub async fn get_project_history_paged(
                 .into_response()
         }
         Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!(ErrorResponse {
+                error: e.to_string()
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /projects/:id/donors`
+///
+/// Returns paginated list of donors for a specific project.
+/// Donors are sorted by total donated amount (descending), then by first donation timestamp (ascending).
+pub async fn get_project_donors(
+    State(state): State<Arc<ApiState>>,
+    Path(project_id): Path<String>,
+    Query(query): Query<DonorsQuery>,
+) -> impl IntoResponse {
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let offset = query.offset.unwrap_or(0).max(0);
+
+    // Get total count and donors in parallel for better performance
+    let (total_count_result, donors_result) = tokio::join!(
+        db::get_project_donors_count(&state.pool, &project_id),
+        db::get_project_donors(&state.pool, &project_id, limit, offset)
+    );
+
+    match (total_count_result, donors_result) {
+        (Ok(total_donors), Ok(donors)) => {
+            (
+                StatusCode::OK,
+                Json(DonorsResponse {
+                    project_id,
+                    total_donors,
+                    donors,
+                }),
+            )
+                .into_response()
+        }
+        (Err(e), _) | (_, Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!(ErrorResponse {
                 error: e.to_string()

--- a/backend/indexer/src/db.rs
+++ b/backend/indexer/src/db.rs
@@ -642,6 +642,83 @@ pub async fn get_project_history(
     Ok(rows)
 }
 
+#[derive(Debug, Clone, Serialize, sqlx::FromRow)]
+pub struct DonorRecord {
+    pub address: String,
+    pub total_donated: String,
+    pub donation_count: i64,
+    pub first_donation_ledger: i64,
+    pub last_donation_ledger: i64,
+    pub first_donation_timestamp: i64,
+    pub last_donation_timestamp: i64,
+}
+
+/// Fetch donors for a specific project with pagination and consistent sorting.
+/// Returns donors sorted by total donated amount (descending), then by first donation timestamp (ascending).
+pub async fn get_project_donors(
+    pool: &SqlitePool,
+    project_id: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<DonorRecord>> {
+    let rows = sqlx::query_as::<_, (String, i64, i64, i64, i64, i64, i64)>(
+        r#"
+        SELECT 
+            actor as address,
+            COALESCE(SUM(CAST(amount AS INTEGER)), 0) as total_donated,
+            COUNT(*) as donation_count,
+            MIN(ledger) as first_donation_ledger,
+            MAX(ledger) as last_donation_ledger,
+            MIN(timestamp) as first_donation_timestamp,
+            MAX(timestamp) as last_donation_timestamp
+        FROM events
+        WHERE project_id = ?1 
+          AND event_type = 'project_funded'
+          AND actor IS NOT NULL
+        GROUP BY actor
+        ORDER BY total_donated DESC, first_donation_timestamp ASC
+        LIMIT ?2 OFFSET ?3
+        "#,
+    )
+    .bind(project_id)
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(pool)
+    .await?;
+    
+    // Convert to DonorRecord structs
+    let donors = rows.into_iter().map(|(address, total_donated, donation_count, first_donation_ledger, last_donation_ledger, first_donation_timestamp, last_donation_timestamp)| {
+        DonorRecord {
+            address,
+            total_donated: total_donated.to_string(),
+            donation_count,
+            first_donation_ledger,
+            last_donation_ledger,
+            first_donation_timestamp,
+            last_donation_timestamp,
+        }
+    }).collect();
+    
+    Ok(donors)
+}
+
+/// Get the total count of unique donors for a specific project.
+pub async fn get_project_donors_count(pool: &SqlitePool, project_id: &str) -> Result<i64> {
+    let row: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(DISTINCT actor)
+        FROM events
+        WHERE project_id = ?1 
+          AND event_type = 'project_funded'
+          AND actor IS NOT NULL
+        "#,
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(row.0)
+}
+
 // ─────────────────────────────────────────────────────────
 // Quorum management
 // ─────────────────────────────────────────────────────────
@@ -1350,5 +1427,154 @@ mod tests {
         let results = search_projects(&pool, "solar", 20, 0).await.unwrap();
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].project_id, "2"); // title match ranks first
+    }
+
+    #[tokio::test]
+    async fn test_get_project_donors() {
+        let pool = setup_test_db().await;
+        let project_id = "test_project";
+
+        // Insert funding events for different donors
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_1")
+            .bind("1000")
+            .bind(100i64)
+            .bind(1000i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_2")
+            .bind("500")
+            .bind(101i64)
+            .bind(1001i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Second donation from donor_1
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_1")
+            .bind("300")
+            .bind(102i64)
+            .bind(1002i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let donors = get_project_donors(&pool, project_id, 10, 0).await.unwrap();
+        assert_eq!(donors.len(), 2);
+
+        // Should be sorted by total donated amount (descending)
+        assert_eq!(donors[0].address, "donor_1");
+        assert_eq!(donors[0].total_donated, "1300");
+        assert_eq!(donors[0].donation_count, 2);
+        assert_eq!(donors[0].first_donation_ledger, 100);
+        assert_eq!(donors[0].last_donation_ledger, 102);
+
+        assert_eq!(donors[1].address, "donor_2");
+        assert_eq!(donors[1].total_donated, "500");
+        assert_eq!(donors[1].donation_count, 1);
+        assert_eq!(donors[1].first_donation_ledger, 101);
+        assert_eq!(donors[1].last_donation_ledger, 101);
+    }
+
+    #[tokio::test]
+    async fn test_get_project_donors_count() {
+        let pool = setup_test_db().await;
+        let project_id = "test_project";
+
+        // Initially no donors
+        let count = get_project_donors_count(&pool, project_id).await.unwrap();
+        assert_eq!(count, 0);
+
+        // Add some funding events
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_1")
+            .bind("1000")
+            .bind(100i64)
+            .bind(1000i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_2")
+            .bind("500")
+            .bind(101i64)
+            .bind(1001i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Multiple donations from same donor should count as 1
+        sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+            .bind("project_funded")
+            .bind(project_id)
+            .bind("donor_1")
+            .bind("300")
+            .bind(102i64)
+            .bind(1002i64)
+            .bind("contract_1")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let count = get_project_donors_count(&pool, project_id).await.unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_project_donors_pagination() {
+        let pool = setup_test_db().await;
+        let project_id = "test_project";
+
+        // Add multiple donors
+        for i in 1..=5 {
+            sqlx::query("INSERT INTO events (event_type, project_id, actor, amount, ledger, timestamp, contract_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)")
+                .bind("project_funded")
+                .bind(project_id)
+                .bind(format!("donor_{}", i))
+                .bind((i * 100).to_string())
+                .bind(i as i64)
+                .bind(i as i64)
+                .bind("contract_1")
+                .execute(&pool)
+                .await
+                .unwrap();
+        }
+
+        // Test first page
+        let donors_page1 = get_project_donors(&pool, project_id, 2, 0).await.unwrap();
+        assert_eq!(donors_page1.len(), 2);
+        assert_eq!(donors_page1[0].address, "donor_5"); // Highest amount
+        assert_eq!(donors_page1[1].address, "donor_4");
+
+        // Test second page
+        let donors_page2 = get_project_donors(&pool, project_id, 2, 2).await.unwrap();
+        assert_eq!(donors_page2.len(), 2);
+        assert_eq!(donors_page2[0].address, "donor_3");
+        assert_eq!(donors_page2[1].address, "donor_2");
+
+        // Test third page
+        let donors_page3 = get_project_donors(&pool, project_id, 2, 4).await.unwrap();
+        assert_eq!(donors_page3.len(), 1);
+        assert_eq!(donors_page3[0].address, "donor_1"); // Lowest amount
     }
 }

--- a/backend/indexer/src/db.rs
+++ b/backend/indexer/src/db.rs
@@ -676,7 +676,7 @@ pub async fn get_project_donors(
           AND event_type = 'project_funded'
           AND actor IS NOT NULL
         GROUP BY actor
-        ORDER BY total_donated DESC, first_donation_timestamp ASC
+        ORDER BY total_donated DESC, first_donation_timestamp ASC, address ASC
         LIMIT ?2 OFFSET ?3
         "#,
     )

--- a/backend/indexer/src/main.rs
+++ b/backend/indexer/src/main.rs
@@ -134,6 +134,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/projects", get(api::get_projects))
         .route("/projects/search", get(api::search_projects))
         .route("/projects/:id/history", get(api::get_project_history_paged))
+        .route("/projects/:id/donors", get(api::get_project_donors))
         .route("/projects/top", get(api::get_top_projects))
         .route(
             "/projects/active/count",

--- a/backend/indexer/test_donors_api.md
+++ b/backend/indexer/test_donors_api.md
@@ -1,0 +1,72 @@
+# Donor List API Implementation
+
+## Overview
+This implementation adds pagination support for the donor list API endpoint to improve performance for projects with thousands of participants.
+
+## New Endpoint
+
+### `GET /projects/:id/donors`
+
+Returns a paginated list of donors for a specific project.
+
+#### Query Parameters
+- `limit` (optional): Number of donors to return per page (default: 20, max: 100)
+- `offset` (optional): Number of donors to skip (default: 0)
+
+#### Response Format
+```json
+{
+  "project_id": "string",
+  "total_donors": 1234,
+  "donors": [
+    {
+      "address": "donor_address_1",
+      "total_donated": "5000",
+      "donation_count": 3,
+      "first_donation_ledger": 12345,
+      "last_donation_ledger": 12567,
+      "first_donation_timestamp": 1640995200,
+      "last_donation_timestamp": 1641081600
+    }
+  ]
+}
+```
+
+#### Sorting
+Donors are sorted by:
+1. Total donated amount (descending) - highest donors first
+2. First donation timestamp (ascending) - earlier donors first for ties
+
+## Database Functions Added
+
+1. `get_project_donors(pool, project_id, limit, offset)` - Fetches paginated donor list
+2. `get_project_donors_count(pool, project_id)` - Gets total count of unique donors
+
+## Features
+
+- **Pagination**: Supports limit/offset pagination
+- **Consistent Sorting**: Deterministic order for reliable pagination
+- **Performance**: Uses efficient SQL queries with proper indexing
+- **Comprehensive Data**: Includes donation statistics per donor
+- **Parallel Queries**: Fetches count and donors simultaneously for better performance
+
+## Example Usage
+
+```bash
+# Get first 20 donors
+curl "http://localhost:8080/projects/project_123/donors"
+
+# Get next 20 donors
+curl "http://localhost:8080/projects/project_123/donors?limit=20&offset=20"
+
+# Get 50 donors starting from position 100
+curl "http://localhost:8080/projects/project_123/donors?limit=50&offset=100"
+```
+
+## Testing
+
+The implementation includes comprehensive tests:
+- Basic donor retrieval and sorting
+- Pagination functionality
+- Donor count accuracy
+- Edge cases (no donors, single donor, etc.)


### PR DESCRIPTION
Closes #145

---

- Add GET /projects/:id/donors endpoint with limit/offset pagination
- Support consistent sorting by total donated amount and first donation timestamp
- Include comprehensive donor statistics (total donated, donation count, timestamps)
- Add parallel query execution for improved performance
- Add comprehensive unit tests for donor retrieval and pagination
- Update API documentation and add integration test script

Resolves performance issues for projects with thousands of donors by providing efficient paginated access to donor information.