### PR TITLE
ci: add SHA256 checksum for WASM release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,33 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
       - name: Build Contract
         run: |
           cargo build --release --target wasm32-unknown-unknown --manifest-path contracts/pifp_protocol/Cargo.toml
+
+      - name: Generate SHA256
+        run: |
+          sha256sum target/wasm32-unknown-unknown/release/pifp_protocol.wasm > target/wasm32-unknown-unknown/release/pifp_protocol.wasm.sha256
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
             target/wasm32-unknown-unknown/release/pifp_protocol.wasm
+            target/wasm32-unknown-unknown/release/pifp_protocol.wasm.sha256
           draft: true
           generate_release_notes: true
         env:


### PR DESCRIPTION
Closes #157

---

## Summary
This PR updates the release workflow to generate a SHA256 checksum for the WASM artifact and upload both files to GitHub Releases.

## Changes
- added SHA256 checksum generation for `pifp_protocol.wasm`
- uploaded both `.wasm` and `.wasm.sha256` to tagged GitHub Releases
- kept the existing release flow intact

