### PR TITLE
feat: Pluggable Oracle Aggregator with Staleness Recovery UI (#222)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -3831,6 +3832,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3891,23 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]
@@ -4565,11 +4593,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "crossbeam-epoch",
  "crossbeam-skiplist",
  "dotenvy",
+ "ed25519-dalek",
  "hex",
  "k256",
  "libp2p",
@@ -5361,6 +5391,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -7528,6 +7559,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/backend/oracle/Cargo.toml
+++ b/backend/oracle/Cargo.toml
@@ -15,11 +15,11 @@ stellar-strkey = "0.0.16"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP server (health + metrics endpoints)
-axum = "0.8"
+axum = { version = "0.8", features = ["multipart"] }
 tower-http = { version = "0.6", features = ["trace"] }
 
 # HTTP client for IPFS
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "multipart"], default-features = false }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
@@ -42,6 +42,8 @@ dotenvy = "0.15"
 # Crypto
 sha2 = "0.11"
 hex = "0.4"
+base64 = "0.22"
+ed25519-dalek = "2"
 k256 = { version = "0.13", features = ["arithmetic", "ecdsa", "serde"] }
 rand = "0.8"
 threshold_crypto = "0.4"

--- a/backend/oracle/src/bridge_api.rs
+++ b/backend/oracle/src/bridge_api.rs
@@ -26,8 +26,8 @@ pub struct BridgeState {
 pub fn router(state: Arc<BridgeState>) -> Router {
     Router::new()
         .route("/bridge/messages", get(get_messages))
-        .route("/bridge/messages/:id", get(get_message))
-        .route("/bridge/sign/:id", post(add_signature))
+    .route("/bridge/messages/{id}", get(get_message))
+    .route("/bridge/sign/{id}", post(add_signature))
         .with_state(state)
 }
 

--- a/backend/oracle/src/config.rs
+++ b/backend/oracle/src/config.rs
@@ -32,6 +32,9 @@ pub struct Config {
     /// Optional Sentry DSN for error tracking
     pub sentry_dsn: Option<String>,
 
+    /// Metrics/HTTP API port for the oracle service.
+    pub metrics_port: u16,
+
     /// Foreign chain RPC URL (e.g., Ethereum/Polygon)
     pub foreign_rpc_url: Option<String>,
 
@@ -181,6 +184,9 @@ mod tests {
             timeout_secs: 30,
             sentry_dsn: None,
             metrics_port: 9090,
+            foreign_rpc_url: None,
+            foreign_bridge_address: None,
+            node_id: 1,
         }
     }
 }

--- a/backend/oracle/src/config.rs
+++ b/backend/oracle/src/config.rs
@@ -1,4 +1,4 @@
-//! Configuration management for the Oracle service.
+﻿//! Configuration management for the Oracle service.
 //!
 //! Loads all required settings from environment variables.
 
@@ -43,24 +43,34 @@ pub struct Config {
 
     /// Node ID for threshold signatures (1-based)
     pub node_id: usize,
+
+    /// Asset symbol to track (e.g., "XLM")
+    pub oracle_asset_symbol: String,
+
+    /// Quote currency symbol (e.g., "USD")
+    pub oracle_quote_symbol: String,
+
+    /// How often to refresh oracle price data (seconds)
+    pub oracle_refresh_secs: u64,
+
+    /// Maximum age of an accepted snapshot before it is declared stale (seconds)
+    pub oracle_max_staleness_secs: u64,
+
+    /// Maximum acceptable inter-provider price deviation percentage
+    pub oracle_max_variance_pct: f64,
+
+    /// CoinGecko price endpoint URL
+    pub oracle_coingecko_url: String,
+
+    /// Binance price endpoint URL
+    pub oracle_binance_url: String,
+
+    /// Kraken price endpoint URL
+    pub oracle_kraken_url: String,
 }
 
 impl Config {
     /// Load configuration from environment variables.
-    ///
-    /// Required variables:
-    /// - `RPC_URL`: Soroban RPC endpoint
-    /// - `CONTRACT_ID`: PIFP contract address
-    /// - `ORACLE_SECRET_KEY`: Oracle's signing key
-    ///
-    /// Optional variables (with defaults):
-    /// - `HORIZON_URL`: Horizon API endpoint (defaults to testnet)
-    /// - `IPFS_GATEWAY`: IPFS gateway (defaults to ipfs.io)
-    /// - `NETWORK_PASSPHRASE`: Network passphrase (defaults to testnet)
-    /// - `TIMEOUT_SECS`: Request timeout (defaults to 30)
-    /// - `FOREIGN_RPC_URL`: Foreign chain RPC URL
-    /// - `FOREIGN_BRIDGE_ADDRESS`: Foreign bridge contract address
-    /// - `NODE_ID`: Node ID for threshold signatures (defaults to 1)
     pub fn from_env() -> Result<Self> {
         Ok(Config {
             rpc_url: env_var("RPC_URL")
@@ -98,47 +108,73 @@ impl Config {
                 .unwrap_or_else(|_| "1".to_string())
                 .parse()
                 .map_err(|_| OracleError::Config("Invalid NODE_ID".to_string()))?,
+
+            oracle_asset_symbol: env_var("ORACLE_ASSET_SYMBOL")
+                .unwrap_or_else(|_| "XLM".to_string()),
+
+            oracle_quote_symbol: env_var("ORACLE_QUOTE_SYMBOL")
+                .unwrap_or_else(|_| "USD".to_string()),
+
+            oracle_refresh_secs: env_var("ORACLE_REFRESH_SECS")
+                .unwrap_or_else(|_| "15".to_string())
+                .parse()
+                .map_err(|_| OracleError::Config("Invalid ORACLE_REFRESH_SECS".to_string()))?,
+
+            oracle_max_staleness_secs: env_var("ORACLE_MAX_STALENESS_SECS")
+                .unwrap_or_else(|_| "90".to_string())
+                .parse()
+                .map_err(|_| OracleError::Config("Invalid ORACLE_MAX_STALENESS_SECS".to_string()))?,
+
+            oracle_max_variance_pct: env_var("ORACLE_MAX_VARIANCE_PCT")
+                .unwrap_or_else(|_| "5.0".to_string())
+                .parse()
+                .map_err(|_| OracleError::Config("Invalid ORACLE_MAX_VARIANCE_PCT".to_string()))?,
+
+            oracle_coingecko_url: env_var("ORACLE_COINGECKO_URL").unwrap_or_else(|_| {
+                "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd"
+                    .to_string()
+            }),
+
+            oracle_binance_url: env_var("ORACLE_BINANCE_URL").unwrap_or_else(|_| {
+                "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT".to_string()
+            }),
+
+            oracle_kraken_url: env_var("ORACLE_KRAKEN_URL").unwrap_or_else(|_| {
+                "https://api.kraken.com/0/public/Ticker?pair=XLMUSD".to_string()
+            }),
         })
     }
 
     /// Validate that all required configuration is present and well-formed.
     #[allow(dead_code)]
     pub fn validate(&self) -> Result<()> {
-        // Validate contract ID format (should start with 'C')
         if !self.contract_id.starts_with('C') {
             return Err(OracleError::Config(
                 "CONTRACT_ID must be a valid Stellar contract address (starts with 'C')"
                     .to_string(),
             ));
         }
-
-        // Validate secret key format (should start with 'S')
         if !self.oracle_secret_key.starts_with('S') {
             return Err(OracleError::Config(
                 "ORACLE_SECRET_KEY must be a valid Stellar secret key (starts with 'S')"
                     .to_string(),
             ));
         }
-
-        // Validate URLs
         if !self.rpc_url.starts_with("http") {
             return Err(OracleError::Config(
                 "RPC_URL must be a valid HTTP(S) URL".to_string(),
             ));
         }
-
         if !self.horizon_url.starts_with("http") {
             return Err(OracleError::Config(
                 "HORIZON_URL must be a valid HTTP(S) URL".to_string(),
             ));
         }
-
         if !self.ipfs_gateway.starts_with("http") {
             return Err(OracleError::Config(
                 "IPFS_GATEWAY must be a valid HTTP(S) URL".to_string(),
             ));
         }
-
         Ok(())
     }
 }
@@ -157,7 +193,6 @@ mod tests {
         let mut config = mock_config();
         config.contract_id = "INVALID".to_string();
         assert!(config.validate().is_err());
-
         config.contract_id = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM".to_string();
         assert!(config.validate().is_ok());
     }
@@ -167,7 +202,6 @@ mod tests {
         let mut config = mock_config();
         config.oracle_secret_key = "INVALID".to_string();
         assert!(config.validate().is_err());
-
         config.oracle_secret_key =
             "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string();
         assert!(config.validate().is_ok());
@@ -187,6 +221,15 @@ mod tests {
             foreign_rpc_url: None,
             foreign_bridge_address: None,
             node_id: 1,
+            oracle_asset_symbol: "XLM".to_string(),
+            oracle_quote_symbol: "USD".to_string(),
+            oracle_refresh_secs: 15,
+            oracle_max_staleness_secs: 90,
+            oracle_max_variance_pct: 5.0,
+            oracle_coingecko_url: "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd".to_string(),
+            oracle_binance_url: "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT".to_string(),
+            oracle_kraken_url: "https://api.kraken.com/0/public/Ticker?pair=XLMUSD".to_string(),
         }
     }
 }
+

--- a/backend/oracle/src/health.rs
+++ b/backend/oracle/src/health.rs
@@ -42,13 +42,15 @@ pub async fn serve(
     bridge_state: Arc<crate::bridge_api::BridgeState>,
     ipfs_state: Arc<crate::ipfs_api::IpfsState>,
     rollup_state: Arc<crate::rollup_api::RollupState>,
+    oracle_state: Arc<crate::oracle_api::OracleApiState>,
 ) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/health", get(health))
         .route("/metrics", get(metrics_handler))
         .merge(crate::bridge_api::router(bridge_state))
         .merge(crate::ipfs_api::router(ipfs_state))
-        .merge(crate::rollup_api::router(rollup_state));
+        .merge(crate::rollup_api::router(rollup_state))
+        .merge(crate::oracle_api::router(oracle_state));
 
     let addr = format!("0.0.0.0:{port}");
     info!("Oracle API server listening on http://{addr}");
@@ -74,12 +76,38 @@ mod tests {
             },
         });
         let rollup_state = Arc::new(crate::rollup_api::RollupState::new(std::time::Duration::from_secs(30)));
+        let oracle_state = Arc::new(
+            crate::oracle_api::OracleApiState::new(&crate::config::Config {
+                rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+                horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+                contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM".to_string(),
+                oracle_secret_key: "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+                ipfs_gateway: "https://ipfs.io".to_string(),
+                network_passphrase: "Test SDF Network ; September 2015".to_string(),
+                timeout_secs: 30,
+                sentry_dsn: None,
+                metrics_port: 9090,
+                oracle_asset_symbol: "XLM".to_string(),
+                oracle_quote_symbol: "USD".to_string(),
+                oracle_refresh_secs: 15,
+                oracle_max_staleness_secs: 90,
+                oracle_max_variance_pct: 5.0,
+                oracle_coingecko_url: "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd".to_string(),
+                oracle_binance_url: "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT".to_string(),
+                oracle_kraken_url: "https://api.kraken.com/0/public/Ticker?pair=XLMUSD".to_string(),
+                foreign_rpc_url: None,
+                foreign_bridge_address: None,
+                node_id: 1,
+            })
+            .expect("oracle state should build in test"),
+        );
         Router::new()
             .route("/health", get(health))
             .route("/metrics", get(metrics_handler))
             .merge(crate::bridge_api::router(bridge_state))
             .merge(crate::ipfs_api::router(ipfs_state))
             .merge(crate::rollup_api::router(rollup_state))
+            .merge(crate::oracle_api::router(oracle_state))
     }
 
     #[tokio::test]

--- a/backend/oracle/src/health.rs
+++ b/backend/oracle/src/health.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::State,
     http::{header, StatusCode},
     response::IntoResponse,
     routing::get,
@@ -20,13 +19,7 @@ struct HealthResponse {
     service: &'static str,
 }
 
-#[derive(Clone)]
-pub struct ServerState {
-    pub bridge: Arc<crate::bridge_api::BridgeState>,
-    pub ipfs: Arc<crate::ipfs_api::IpfsState>,
-}
-
-async fn health(State(_state): State<Arc<ServerState>>) -> impl IntoResponse {
+async fn health() -> impl IntoResponse {
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
@@ -48,18 +41,14 @@ pub async fn serve(
     port: u16,
     bridge_state: Arc<crate::bridge_api::BridgeState>,
     ipfs_state: Arc<crate::ipfs_api::IpfsState>,
+    rollup_state: Arc<crate::rollup_api::RollupState>,
 ) -> anyhow::Result<()> {
-    let state = Arc::new(ServerState {
-        bridge: bridge_state.clone(),
-        ipfs: ipfs_state.clone(),
-    });
-
     let app = Router::new()
         .route("/health", get(health))
         .route("/metrics", get(metrics_handler))
-        .nest("/api", crate::bridge_api::router(bridge_state))
-        .nest("/api", crate::ipfs_api::router(ipfs_state))
-        .with_state(state);
+        .merge(crate::bridge_api::router(bridge_state))
+        .merge(crate::ipfs_api::router(ipfs_state))
+        .merge(crate::rollup_api::router(rollup_state));
 
     let addr = format!("0.0.0.0:{port}");
     info!("Oracle API server listening on http://{addr}");
@@ -84,16 +73,13 @@ mod tests {
                 web3_storage_token: None,
             },
         });
-        let state = Arc::new(ServerState {
-            bridge: bridge_state.clone(),
-            ipfs: ipfs_state.clone(),
-        });
+        let rollup_state = Arc::new(crate::rollup_api::RollupState::new(std::time::Duration::from_secs(30)));
         Router::new()
             .route("/health", get(health))
             .route("/metrics", get(metrics_handler))
-            .nest("/api", crate::bridge_api::router(bridge_state))
-            .nest("/api", crate::ipfs_api::router(ipfs_state))
-            .with_state(state)
+            .merge(crate::bridge_api::router(bridge_state))
+            .merge(crate::ipfs_api::router(ipfs_state))
+            .merge(crate::rollup_api::router(rollup_state))
     }
 
     #[tokio::test]

--- a/backend/oracle/src/ipfs.rs
+++ b/backend/oracle/src/ipfs.rs
@@ -53,7 +53,7 @@ pub async fn pin_file(data: Vec<u8>, config: &IpfsConfig) -> Result<String> {
 
     if config.pinata_api_key.is_some() && config.pinata_api_secret.is_some() {
         info!("Attempting to pin via Pinata");
-        match pin_with_retry(data.clone(), config, pin_via_pinata).await {
+        match pin_with_retry_pinata(data.clone(), config).await {
             Ok(cid) => {
                 info!(cid = %cid, "Pinned via Pinata");
                 return Ok(cid);
@@ -66,7 +66,7 @@ pub async fn pin_file(data: Vec<u8>, config: &IpfsConfig) -> Result<String> {
 
     if config.web3_storage_token.is_some() {
         info!("Attempting to pin via Web3.Storage");
-        match pin_with_retry(data, config, pin_via_web3_storage).await {
+        match pin_with_retry_web3_storage(data, config).await {
             Ok(cid) => {
                 info!(cid = %cid, "Pinned via Web3.Storage");
                 return Ok(cid);
@@ -83,15 +83,7 @@ pub async fn pin_file(data: Vec<u8>, config: &IpfsConfig) -> Result<String> {
     ))
 }
 
-async fn pin_with_retry<F, Fut>(
-    data: Vec<u8>,
-    config: &IpfsConfig,
-    pin_fn: F,
-) -> Result<String>
-where
-    F: Fn(Vec<u8>, &IpfsConfig, Client) -> Fut,
-    Fut: std::future::Future<Output = Result<String>>,
-{
+async fn pin_with_retry_pinata(data: Vec<u8>, config: &IpfsConfig) -> Result<String> {
     let mut last_err = OracleError::Network("No attempts made".to_string());
 
     for attempt in 0..MAX_RETRIES {
@@ -103,7 +95,31 @@ where
 
         let client = build_client()?;
 
-        match pin_fn(data.clone(), config, client).await {
+        match pin_via_pinata(data.clone(), config, client).await {
+            Ok(cid) => return Ok(cid),
+            Err(e) => {
+                warn!(attempt, error = %e, "IPFS pin attempt failed");
+                last_err = e;
+            }
+        }
+    }
+
+    Err(last_err)
+}
+
+async fn pin_with_retry_web3_storage(data: Vec<u8>, config: &IpfsConfig) -> Result<String> {
+    let mut last_err = OracleError::Network("No attempts made".to_string());
+
+    for attempt in 0..MAX_RETRIES {
+        if attempt > 0 {
+            let backoff = BASE_BACKOFF_MS * (1 << (attempt - 1));
+            warn!(attempt, backoff_ms = backoff, "Retrying IPFS pin after backoff");
+            tokio::time::sleep(Duration::from_millis(backoff)).await;
+        }
+
+        let client = build_client()?;
+
+        match pin_via_web3_storage(data.clone(), config, client).await {
             Ok(cid) => return Ok(cid),
             Err(e) => {
                 warn!(attempt, error = %e, "IPFS pin attempt failed");

--- a/backend/oracle/src/ipfs_api.rs
+++ b/backend/oracle/src/ipfs_api.rs
@@ -1,17 +1,22 @@
 use axum::{
     extract::{Multipart, State},
+    http::StatusCode,
     routing::post,
     Json, Router,
 };
 use serde::Serialize;
 use std::sync::Arc;
 use crate::ipfs::{pin_file, IpfsConfig};
-use crate::errors::Result;
 
 #[derive(Serialize)]
 pub struct UploadResponse {
     pub cid: String,
     pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct UploadErrorResponse {
+    pub error: String,
 }
 
 pub struct IpfsState {
@@ -27,23 +32,57 @@ pub fn router(state: Arc<IpfsState>) -> Router {
 async fn upload_file(
     State(state): State<Arc<IpfsState>>,
     mut multipart: Multipart,
-) -> Result<Json<UploadResponse>> {
+) -> std::result::Result<Json<UploadResponse>, (StatusCode, Json<UploadErrorResponse>)> {
     let mut file_data = Vec::new();
 
-    while let Some(field) = multipart.next_field().await.map_err(|e| crate::errors::OracleError::Network(format!("Multipart error: {}", e)))? {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(UploadErrorResponse {
+                    error: format!("Multipart error: {e}"),
+                }),
+            )
+        })?
+    {
         if let Some(name) = field.name() {
             if name == "file" {
-                file_data = field.bytes().await.map_err(|e| crate::errors::OracleError::Network(format!("Field bytes error: {}", e)))?.to_vec();
+                file_data = field
+                    .bytes()
+                    .await
+                    .map_err(|e| {
+                        (
+                            StatusCode::BAD_REQUEST,
+                            Json(UploadErrorResponse {
+                                error: format!("Field bytes error: {e}"),
+                            }),
+                        )
+                    })?
+                    .to_vec();
                 break;
             }
         }
     }
 
     if file_data.is_empty() {
-        return Err(crate::errors::OracleError::Verification("No file data provided".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(UploadErrorResponse {
+                error: "No file data provided".to_string(),
+            }),
+        ));
     }
 
-    let cid = pin_file(file_data, &state.config).await?;
+    let cid = pin_file(file_data, &state.config).await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(UploadErrorResponse {
+                error: e.to_string(),
+            }),
+        )
+    })?;
 
     Ok(Json(UploadResponse {
         cid,

--- a/backend/oracle/src/main.rs
+++ b/backend/oracle/src/main.rs
@@ -14,6 +14,7 @@ mod observer;
 mod bridge_api;
 mod ipfs_api;
 mod ipfs;
+mod oracle_api;
 mod rollup_api;
 
 use std::sync::Arc;
@@ -21,6 +22,7 @@ use std::sync::Arc;
 use crate::bridge_api::BridgeState;
 use crate::ipfs_api::IpfsState;
 use crate::ipfs::IpfsConfig;
+use crate::oracle_api::OracleApiState;
 use crate::observer::BridgeObserver;
 use crate::rollup_api::RollupState;
 
@@ -136,7 +138,8 @@ async fn main() -> anyhow::Result<()> {
 
     if cli.serve {
         rollup_state.clone().start_settlement_loop();
-        health::serve(config.metrics_port, bridge_state, ipfs_state, rollup_state).await?;
+        let oracle_state = Arc::new(OracleApiState::new(config.as_ref())?);
+        health::serve(config.metrics_port, bridge_state, ipfs_state, rollup_state, oracle_state).await?;
         return Ok(());
     }
 

--- a/backend/oracle/src/main.rs
+++ b/backend/oracle/src/main.rs
@@ -14,6 +14,7 @@ mod observer;
 mod bridge_api;
 mod ipfs_api;
 mod ipfs;
+mod rollup_api;
 
 use std::sync::Arc;
 
@@ -21,6 +22,7 @@ use crate::bridge_api::BridgeState;
 use crate::ipfs_api::IpfsState;
 use crate::ipfs::IpfsConfig;
 use crate::observer::BridgeObserver;
+use crate::rollup_api::RollupState;
 
 use clap::Parser;
 use sentry::{self, protocol::Event};
@@ -115,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
     let ipfs_state = Arc::new(IpfsState {
         config: IpfsConfig::from_env(),
     });
+    let rollup_state = Arc::new(RollupState::new(std::time::Duration::from_secs(15)));
 
     // Start Bridge Observer in the background if configured
     let observer_config = Arc::clone(&config);
@@ -132,7 +135,8 @@ async fn main() -> anyhow::Result<()> {
     });
 
     if cli.serve {
-        health::serve(config.metrics_port, bridge_state, ipfs_state).await?;
+        rollup_state.clone().start_settlement_loop();
+        health::serve(config.metrics_port, bridge_state, ipfs_state, rollup_state).await?;
         return Ok(());
     }
 

--- a/backend/oracle/src/oracle_api.rs
+++ b/backend/oracle/src/oracle_api.rs
@@ -1,0 +1,753 @@
+﻿//! Pluggable Oracle Aggregator – concurrent multi-provider price fetching with
+//! medianizer-based outlier filtering, staleness detection, variance scoring,
+//! and a health-score endpoint consumed by the frontend staleness-recovery UI.
+
+use std::{
+    cmp::Ordering,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use axum::{extract::State, routing::get, Json, Router};
+use reqwest::Client;
+use serde::Serialize;
+use tokio::task::JoinSet;
+
+use crate::config::Config;
+use crate::errors::OracleError;
+
+// ── Public response types ─────────────────────────────────────────────────────
+
+/// JSON body returned by `GET /oracle/quote`.
+#[derive(Debug, Clone, Serialize)]
+pub struct OracleSnapshotResponse {
+    pub asset_symbol: String,
+    pub quote_symbol: String,
+    pub aggregated_price: Option<f64>,
+    pub health_score: u8,
+    pub status: String,
+    /// "green" | "yellow" | "red"
+    pub indicator: String,
+    pub stale: bool,
+    pub high_variance: bool,
+    pub variance_pct: f64,
+    pub max_sample_age_secs: u64,
+    pub updated_at_unix: u64,
+    pub provider_count: usize,
+    pub contributing_provider_count: usize,
+    pub summary: String,
+    pub reasons: Vec<String>,
+    pub recovery_actions: Vec<String>,
+    pub providers: Vec<ProviderObservation>,
+}
+
+/// Per-provider observation included in the snapshot.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderObservation {
+    pub provider: String,
+    pub price: Option<f64>,
+    pub status: String,
+    pub age_secs: u64,
+    pub detail: String,
+    pub used_in_aggregation: bool,
+}
+
+// ── Internal types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct CachedSnapshot {
+    aggregated_price: Option<f64>,
+    variance_pct: f64,
+    updated_at_unix: u64,
+    providers: Vec<CachedProviderObservation>,
+    refresh_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedProviderObservation {
+    provider: String,
+    price: Option<f64>,
+    status: String,
+    observed_at_unix: u64,
+    detail: String,
+    used_in_aggregation: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderSample {
+    provider: String,
+    price: f64,
+    observed_at_unix: u64,
+}
+
+#[derive(Debug, Clone)]
+enum ProviderFetchResult {
+    Sample(ProviderSample),
+    Error(CachedProviderObservation),
+}
+
+#[derive(Debug, Clone)]
+struct OracleRuntime {
+    asset_symbol: String,
+    quote_symbol: String,
+    refresh_interval: Duration,
+    max_staleness_secs: u64,
+    max_variance_pct: f64,
+    providers: Vec<OracleProvider>,
+}
+
+/// Shared state for the oracle aggregator API.
+#[derive(Debug)]
+pub struct OracleApiState {
+    client: Client,
+    runtime: OracleRuntime,
+    cache: Mutex<Option<CachedSnapshot>>,
+}
+
+#[derive(Debug, Clone)]
+struct OracleProvider {
+    name: &'static str,
+    url: String,
+    parser: ProviderParser,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProviderParser {
+    CoinGecko,
+    Binance,
+    Kraken,
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+pub fn router(state: Arc<OracleApiState>) -> Router {
+    Router::new()
+        .route("/oracle/quote", get(get_oracle_quote))
+        .with_state(state)
+}
+
+async fn get_oracle_quote(
+    State(state): State<Arc<OracleApiState>>,
+) -> Json<OracleSnapshotResponse> {
+    Json(state.snapshot().await)
+}
+
+// ── OracleApiState impl ───────────────────────────────────────────────────────
+
+impl OracleApiState {
+    pub fn new(config: &Config) -> Result<Self, OracleError> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(config.timeout_secs))
+            .build()
+            .map_err(|e| {
+                OracleError::Network(format!("Failed to build oracle HTTP client: {e}"))
+            })?;
+
+        Ok(Self {
+            client,
+            runtime: OracleRuntime {
+                asset_symbol: config.oracle_asset_symbol.clone(),
+                quote_symbol: config.oracle_quote_symbol.clone(),
+                refresh_interval: Duration::from_secs(config.oracle_refresh_secs),
+                max_staleness_secs: config.oracle_max_staleness_secs,
+                max_variance_pct: config.oracle_max_variance_pct,
+                providers: vec![
+                    OracleProvider {
+                        name: "CoinGecko",
+                        url: config.oracle_coingecko_url.clone(),
+                        parser: ProviderParser::CoinGecko,
+                    },
+                    OracleProvider {
+                        name: "Binance",
+                        url: config.oracle_binance_url.clone(),
+                        parser: ProviderParser::Binance,
+                    },
+                    OracleProvider {
+                        name: "Kraken",
+                        url: config.oracle_kraken_url.clone(),
+                        parser: ProviderParser::Kraken,
+                    },
+                ],
+            },
+            cache: Mutex::new(None),
+        })
+    }
+
+    async fn snapshot(&self) -> OracleSnapshotResponse {
+        let now = now_unix();
+
+        if let Some(cached) = self.cache.lock().unwrap().clone() {
+            if now.saturating_sub(cached.updated_at_unix) < self.runtime.refresh_interval.as_secs() {
+                return self.materialize(cached, now);
+            }
+        }
+
+        match self.refresh().await {
+            Ok(fresh) => {
+                self.cache.lock().unwrap().replace(fresh.clone());
+                self.materialize(fresh, now)
+            }
+            Err(err) => {
+                if let Some(mut cached) = self.cache.lock().unwrap().clone() {
+                    cached.refresh_error = Some(err);
+                    return self.materialize(cached, now);
+                }
+                self.materialize(
+                    CachedSnapshot {
+                        aggregated_price: None,
+                        variance_pct: 0.0,
+                        updated_at_unix: now,
+                        providers: self
+                            .runtime
+                            .providers
+                            .iter()
+                            .map(|p| CachedProviderObservation {
+                                provider: p.name.to_string(),
+                                price: None,
+                                status: "error".to_string(),
+                                observed_at_unix: now,
+                                detail: "No provider data available yet".to_string(),
+                                used_in_aggregation: false,
+                            })
+                            .collect(),
+                        refresh_error: Some(err),
+                    },
+                    now,
+                )
+            }
+        }
+    }
+
+    async fn refresh(&self) -> Result<CachedSnapshot, String> {
+        let mut tasks: JoinSet<ProviderFetchResult> = JoinSet::new();
+
+        for provider in self.runtime.providers.clone() {
+            let client = self.client.clone();
+            tasks.spawn(async move { fetch_provider_sample(client, provider).await });
+        }
+
+        let mut observations: Vec<CachedProviderObservation> = Vec::new();
+        let mut samples: Vec<ProviderSample> = Vec::new();
+
+        while let Some(result) = tasks.join_next().await {
+            match result {
+                Ok(ProviderFetchResult::Sample(s)) => {
+                    observations.push(CachedProviderObservation {
+                        provider: s.provider.clone(),
+                        price: Some(s.price),
+                        status: "ok".to_string(),
+                        observed_at_unix: s.observed_at_unix,
+                        detail: "Provider responded successfully".to_string(),
+                        used_in_aggregation: false,
+                    });
+                    samples.push(s);
+                }
+                Ok(ProviderFetchResult::Error(e)) => observations.push(e),
+                Err(err) => observations.push(CachedProviderObservation {
+                    provider: "task".to_string(),
+                    price: None,
+                    status: "error".to_string(),
+                    observed_at_unix: now_unix(),
+                    detail: format!("Provider task failed: {err}"),
+                    used_in_aggregation: false,
+                }),
+            }
+        }
+
+        if samples.is_empty() {
+            return Err("All oracle providers failed; no price could be aggregated".to_string());
+        }
+
+        let raw_median = median_price(&samples);
+        let tolerance = self.runtime.max_variance_pct / 100.0;
+        let mut contributing: Vec<ProviderSample> = Vec::new();
+
+        for s in &samples {
+            let dev = relative_deviation(s.price, raw_median);
+            let accepted = dev <= tolerance || raw_median == 0.0;
+
+            if accepted {
+                contributing.push(s.clone());
+            }
+
+            if let Some(obs) = observations.iter_mut().find(|o| o.provider == s.provider) {
+                if accepted {
+                    obs.used_in_aggregation = true;
+                    obs.detail = format!(
+                        "Included in medianizer ({:.2}% from pre-filter median)",
+                        dev * 100.0
+                    );
+                } else {
+                    obs.status = "outlier".to_string();
+                    obs.detail = format!(
+                        "Discarded as outlier ({:.2}% from pre-filter median)",
+                        dev * 100.0
+                    );
+                }
+            }
+        }
+
+        if contributing.is_empty() {
+            return Err("Medianizer rejected every provider sample".to_string());
+        }
+
+        let aggregated_price = median_price(&contributing);
+        let variance_pct = contributing
+            .iter()
+            .map(|s| relative_deviation(s.price, aggregated_price) * 100.0)
+            .fold(0.0_f64, f64::max);
+
+        Ok(CachedSnapshot {
+            aggregated_price: Some(aggregated_price),
+            variance_pct,
+            updated_at_unix: now_unix(),
+            providers: observations,
+            refresh_error: None,
+        })
+    }
+
+    fn materialize(&self, cached: CachedSnapshot, now: u64) -> OracleSnapshotResponse {
+        let max_sample_age_secs = now.saturating_sub(cached.updated_at_unix);
+        let provider_count = cached.providers.len();
+        let contributing_provider_count = cached
+            .providers
+            .iter()
+            .filter(|p| p.used_in_aggregation)
+            .count();
+        let stale = max_sample_age_secs > self.runtime.max_staleness_secs;
+        let high_variance = cached.variance_pct > self.runtime.max_variance_pct;
+
+        let coverage_penalty = if provider_count == 0 {
+            25.0
+        } else {
+            (provider_count.saturating_sub(contributing_provider_count)) as f64
+                / provider_count as f64
+                * 20.0
+        };
+
+        let stale_penalty = if stale {
+            let overshoot = max_sample_age_secs.saturating_sub(self.runtime.max_staleness_secs) as f64;
+            40.0 + (overshoot / self.runtime.max_staleness_secs.max(1) as f64 * 20.0).min(20.0)
+        } else {
+            (max_sample_age_secs as f64 / self.runtime.max_staleness_secs.max(1) as f64) * 12.0
+        };
+
+        let variance_penalty = if high_variance {
+            let overshoot = cached.variance_pct - self.runtime.max_variance_pct;
+            30.0 + (overshoot / self.runtime.max_variance_pct.max(0.1) * 15.0).min(15.0)
+        } else {
+            (cached.variance_pct / self.runtime.max_variance_pct.max(0.1)) * 18.0
+        };
+
+        let availability_penalty = if cached.aggregated_price.is_some() { 0.0 } else { 55.0 };
+        let refresh_penalty = if cached.refresh_error.is_some() { 10.0 } else { 0.0 };
+
+        let raw_score = 100.0
+            - stale_penalty
+            - variance_penalty
+            - coverage_penalty
+            - availability_penalty
+            - refresh_penalty;
+        let health_score = raw_score.clamp(0.0, 100.0).round() as u8;
+
+        let indicator = if health_score >= 80 { "green" } else if health_score >= 55 { "yellow" } else { "red" };
+        let status = match indicator { "green" => "healthy", "yellow" => "degraded", _ => "critical" };
+
+        let mut reasons: Vec<String> = Vec::new();
+        if cached.aggregated_price.is_none() {
+            reasons.push("No aggregated price is currently available".to_string());
+        }
+        if stale {
+            reasons.push(format!(
+                "Oracle snapshot is stale at {} seconds old (limit: {}s)",
+                max_sample_age_secs, self.runtime.max_staleness_secs
+            ));
+        }
+        if high_variance {
+            reasons.push(format!(
+                "Provider variance is {:.2}% which exceeds the {:.2}% safety threshold",
+                cached.variance_pct, self.runtime.max_variance_pct
+            ));
+        }
+        if contributing_provider_count < provider_count {
+            reasons.push(format!(
+                "Only {} of {} providers contributed to the final median",
+                contributing_provider_count, provider_count
+            ));
+        }
+        if let Some(ref err) = cached.refresh_error {
+            reasons.push(format!("Latest refresh attempt failed: {err}"));
+        }
+
+        let summary = if cached.aggregated_price.is_none() {
+            "Oracle data is unavailable. Protocol actions remain disabled until fresh price feeds recover.".to_string()
+        } else if stale || high_variance {
+            "Oracle protection mode is active. Critical actions should stay paused until fresh, low-variance data returns.".to_string()
+        } else if indicator == "yellow" {
+            "Oracle data is available but slightly degraded. Monitor feed freshness before large actions.".to_string()
+        } else {
+            "Oracle data is fresh and variance is within the safety envelope.".to_string()
+        };
+
+        let recovery_actions = vec![
+            "Wait for the oracle service to refresh provider responses.".to_string(),
+            "Check upstream provider connectivity if the degraded state persists.".to_string(),
+            "Retry protocol actions only after the indicator returns to green or the warning is cleared.".to_string(),
+        ];
+
+        OracleSnapshotResponse {
+            asset_symbol: self.runtime.asset_symbol.clone(),
+            quote_symbol: self.runtime.quote_symbol.clone(),
+            aggregated_price: cached.aggregated_price.map(round_four_decimals),
+            health_score,
+            status: status.to_string(),
+            indicator: indicator.to_string(),
+            stale,
+            high_variance,
+            variance_pct: round_two_decimals(cached.variance_pct),
+            max_sample_age_secs,
+            updated_at_unix: cached.updated_at_unix,
+            provider_count,
+            contributing_provider_count,
+            summary,
+            reasons,
+            recovery_actions,
+            providers: cached
+                .providers
+                .into_iter()
+                .map(|p| ProviderObservation {
+                    provider: p.provider,
+                    price: p.price.map(round_four_decimals),
+                    status: p.status,
+                    age_secs: now.saturating_sub(p.observed_at_unix),
+                    detail: p.detail,
+                    used_in_aggregation: p.used_in_aggregation,
+                })
+                .collect(),
+        }
+    }
+}
+
+// ── Concurrent provider fetching ──────────────────────────────────────────────
+
+async fn fetch_provider_sample(client: Client, provider: OracleProvider) -> ProviderFetchResult {
+    let observed_at_unix = now_unix();
+    let response = match client.get(&provider.url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return ProviderFetchResult::Error(CachedProviderObservation {
+                provider: provider.name.to_string(),
+                price: None,
+                status: "error".to_string(),
+                observed_at_unix,
+                detail: format!("Request failed: {e}"),
+                used_in_aggregation: false,
+            })
+        }
+    };
+
+    let http_status = response.status();
+    let body = match response.text().await {
+        Ok(b) => b,
+        Err(e) => {
+            return ProviderFetchResult::Error(CachedProviderObservation {
+                provider: provider.name.to_string(),
+                price: None,
+                status: "error".to_string(),
+                observed_at_unix,
+                detail: format!("Failed to read response body: {e}"),
+                used_in_aggregation: false,
+            })
+        }
+    };
+
+    if !http_status.is_success() {
+        return ProviderFetchResult::Error(CachedProviderObservation {
+            provider: provider.name.to_string(),
+            price: None,
+            status: "error".to_string(),
+            observed_at_unix,
+            detail: format!("HTTP {http_status}: {body}"),
+            used_in_aggregation: false,
+        });
+    }
+
+    match provider.parser.parse_price(&body) {
+        Ok(price) => ProviderFetchResult::Sample(ProviderSample {
+            provider: provider.name.to_string(),
+            price,
+            observed_at_unix,
+        }),
+        Err(err) => ProviderFetchResult::Error(CachedProviderObservation {
+            provider: provider.name.to_string(),
+            price: None,
+            status: "error".to_string(),
+            observed_at_unix,
+            detail: err,
+            used_in_aggregation: false,
+        }),
+    }
+}
+
+// ── Provider-specific JSON parsers ────────────────────────────────────────────
+
+impl ProviderParser {
+    fn parse_price(self, body: &str) -> Result<f64, String> {
+        let value: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| format!("Invalid JSON payload: {e}"))?;
+
+        let price: Option<f64> = match self {
+            ProviderParser::CoinGecko => value
+                .get("stellar")
+                .and_then(|s| s.get("usd"))
+                .and_then(|p| p.as_f64()),
+            ProviderParser::Binance => value
+                .get("price")
+                .and_then(|p| p.as_str())
+                .and_then(|s| s.parse::<f64>().ok()),
+            ProviderParser::Kraken => value
+                .get("result")
+                .and_then(|r| r.as_object())
+                .and_then(|r| r.values().next())
+                .and_then(|e| e.get("c"))
+                .and_then(|c| c.get(0))
+                .and_then(|p| p.as_str())
+                .and_then(|s| s.parse::<f64>().ok()),
+        };
+
+        match price {
+            Some(p) if p.is_finite() && p > 0.0 => Ok(p),
+            _ => Err("Provider payload did not contain a positive finite price".to_string()),
+        }
+    }
+}
+
+// ── Maths helpers ─────────────────────────────────────────────────────────────
+
+fn median_price(samples: &[ProviderSample]) -> f64 {
+    let mut prices: Vec<f64> = samples.iter().map(|s| s.price).collect();
+    prices.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    let mid = prices.len() / 2;
+    if prices.len() % 2 == 0 {
+        (prices[mid - 1] + prices[mid]) / 2.0
+    } else {
+        prices[mid]
+    }
+}
+
+fn relative_deviation(value: f64, reference: f64) -> f64 {
+    if reference == 0.0 { 0.0 } else { (value - reference).abs() / reference.abs() }
+}
+
+fn round_two_decimals(v: f64) -> f64 { (v * 100.0).round() / 100.0 }
+fn round_four_decimals(v: f64) -> f64 { (v * 10_000.0).round() / 10_000.0 }
+
+fn now_unix() -> u64 {
+    chrono::Utc::now().timestamp().max(0) as u64
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> Config {
+        Config {
+            rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+            horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+            contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM".to_string(),
+            oracle_secret_key: "SAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string(),
+            ipfs_gateway: "https://ipfs.io".to_string(),
+            network_passphrase: "Test SDF Network ; September 2015".to_string(),
+            timeout_secs: 30,
+            sentry_dsn: None,
+            metrics_port: 9090,
+            oracle_asset_symbol: "XLM".to_string(),
+            oracle_quote_symbol: "USD".to_string(),
+            oracle_refresh_secs: 15,
+            oracle_max_staleness_secs: 90,
+            oracle_max_variance_pct: 5.0,
+            oracle_coingecko_url: "https://api.coingecko.com/api/v3/simple/price?ids=stellar&vs_currencies=usd".to_string(),
+            oracle_binance_url: "https://api.binance.com/api/v3/ticker/price?symbol=XLMUSDT".to_string(),
+            oracle_kraken_url: "https://api.kraken.com/0/public/Ticker?pair=XLMUSD".to_string(),
+            foreign_rpc_url: None,
+            foreign_bridge_address: None,
+            node_id: 1,
+        }
+    }
+
+    fn make_state() -> OracleApiState {
+        OracleApiState::new(&test_config()).expect("state should build")
+    }
+
+    fn sample(provider: &str, price: f64) -> ProviderSample {
+        ProviderSample { provider: provider.to_string(), price, observed_at_unix: now_unix() }
+    }
+
+    fn obs(provider: &str, price: Option<f64>, used: bool) -> CachedProviderObservation {
+        CachedProviderObservation {
+            provider: provider.to_string(),
+            price,
+            status: if used { "ok" } else { "outlier" }.to_string(),
+            observed_at_unix: now_unix(),
+            detail: String::new(),
+            used_in_aggregation: used,
+        }
+    }
+
+    #[test]
+    fn median_of_three_returns_middle() {
+        let samples = vec![sample("A", 0.10), sample("B", 0.12), sample("C", 0.11)];
+        assert!((median_price(&samples) - 0.11).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn median_of_two_returns_average() {
+        let samples = vec![sample("A", 0.10), sample("B", 0.12)];
+        assert!((median_price(&samples) - 0.11).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn relative_deviation_symmetric() {
+        assert!((relative_deviation(0.105, 0.10) - 0.05).abs() < 1e-9);
+        assert!((relative_deviation(0.095, 0.10) - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn relative_deviation_zero_reference() {
+        assert_eq!(relative_deviation(0.1, 0.0), 0.0);
+    }
+
+    #[test]
+    fn medianizer_discards_outliers_above_threshold() {
+        let state = make_state();
+        let now = now_unix();
+        let snap = state.materialize(
+            CachedSnapshot {
+                aggregated_price: Some(0.103),
+                variance_pct: 0.97,
+                updated_at_unix: now,
+                providers: vec![
+                    obs("CoinGecko", Some(0.102), true),
+                    obs("Binance", Some(0.103), true),
+                    obs("Kraken", Some(0.120), false),
+                ],
+                refresh_error: None,
+            },
+            now,
+        );
+        assert_eq!(snap.contributing_provider_count, 2);
+        assert_eq!(snap.provider_count, 3);
+        assert_eq!(snap.indicator, "green");
+    }
+
+    #[test]
+    fn materialized_snapshot_flags_staleness_and_variance() {
+        let state = make_state();
+        let now = now_unix();
+        let snap = state.materialize(
+            CachedSnapshot {
+                aggregated_price: Some(0.101),
+                variance_pct: 6.2,
+                updated_at_unix: now - 180,
+                providers: vec![obs("CoinGecko", Some(0.101), true)],
+                refresh_error: Some("Binance timeout".to_string()),
+            },
+            now,
+        );
+        assert!(snap.stale);
+        assert!(snap.high_variance);
+        assert_eq!(snap.indicator, "red");
+        assert!(snap.reasons.iter().any(|r| r.contains("Latest refresh attempt failed")));
+    }
+
+    #[test]
+    fn missing_price_is_red() {
+        let state = make_state();
+        let now = now_unix();
+        let snap = state.materialize(
+            CachedSnapshot {
+                aggregated_price: None,
+                variance_pct: 0.0,
+                updated_at_unix: now,
+                providers: vec![obs("Binance", None, false)],
+                refresh_error: Some("timeout".to_string()),
+            },
+            now,
+        );
+        assert_eq!(snap.indicator, "red");
+    }
+
+    #[test]
+    fn coingecko_parser_extracts_price() {
+        let body = r#"{"stellar":{"usd":0.1025}}"#;
+        let price = ProviderParser::CoinGecko.parse_price(body).unwrap();
+        assert!((price - 0.1025).abs() < 1e-10);
+    }
+
+    #[test]
+    fn binance_parser_extracts_price() {
+        let body = r#"{"symbol":"XLMUSDT","price":"0.1019"}"#;
+        let price = ProviderParser::Binance.parse_price(body).unwrap();
+        assert!((price - 0.1019).abs() < 1e-10);
+    }
+
+    #[test]
+    fn kraken_parser_extracts_price() {
+        let body = r#"{"result":{"XXLMZUSD":{"c":["0.1018","1"]}}}"#;
+        let price = ProviderParser::Kraken.parse_price(body).unwrap();
+        assert!((price - 0.1018).abs() < 1e-10);
+    }
+
+    #[test]
+    fn parser_rejects_invalid_json() {
+        assert!(ProviderParser::CoinGecko.parse_price("not-json").is_err());
+    }
+
+    #[test]
+    fn parser_rejects_zero_price() {
+        assert!(ProviderParser::CoinGecko.parse_price(r#"{"stellar":{"usd":0}}"#).is_err());
+    }
+
+    #[tokio::test]
+    async fn refresh_aggregates_mocked_provider_responses() {
+        let mut server = mockito::Server::new_async().await;
+        let _cg = server.mock("GET", "/coingecko").with_status(200)
+            .with_body(r#"{"stellar":{"usd":0.102}}"#).create_async().await;
+        let _bn = server.mock("GET", "/binance").with_status(200)
+            .with_body(r#"{"price":"0.101"}"#).create_async().await;
+        let _kr = server.mock("GET", "/kraken").with_status(200)
+            .with_body(r#"{"result":{"XXLMZUSD":{"c":["0.115","1"]}}}"#).create_async().await;
+
+        let mut config = test_config();
+        config.oracle_coingecko_url = format!("{}/coingecko", server.url());
+        config.oracle_binance_url = format!("{}/binance", server.url());
+        config.oracle_kraken_url = format!("{}/kraken", server.url());
+
+        let state = OracleApiState::new(&config).expect("state should build");
+        let cached = state.refresh().await.expect("refresh should succeed");
+
+        assert!(cached.aggregated_price.is_some());
+        let contrib = cached.providers.iter().filter(|p| p.used_in_aggregation).count();
+        assert_eq!(contrib, 2);
+        assert!(cached.providers.iter().any(|p| p.status == "outlier"));
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_err_when_all_providers_fail() {
+        let mut server = mockito::Server::new_async().await;
+        let _cg = server.mock("GET", "/coingecko").with_status(500).create_async().await;
+        let _bn = server.mock("GET", "/binance").with_status(500).create_async().await;
+        let _kr = server.mock("GET", "/kraken").with_status(500).create_async().await;
+
+        let mut config = test_config();
+        config.oracle_coingecko_url = format!("{}/coingecko", server.url());
+        config.oracle_binance_url = format!("{}/binance", server.url());
+        config.oracle_kraken_url = format!("{}/kraken", server.url());
+
+        let state = OracleApiState::new(&config).expect("state should build");
+        let result = state.refresh().await;
+        assert!(result.is_err());
+    }
+}

--- a/backend/oracle/src/rollup_api.rs
+++ b/backend/oracle/src/rollup_api.rs
@@ -1,0 +1,455 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubmitIntentRequest {
+    pub domain: String,
+    pub chain_id: String,
+    pub donor: String,
+    pub project_id: u64,
+    pub amount_stroops: u64,
+    pub nonce: u64,
+    pub expires_at: u64,
+    pub message: String,
+    pub signature: String,
+    pub public_key: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubmitIntentResponse {
+    pub accepted: bool,
+    pub intent_id: String,
+    pub pending_balance_stroops: u64,
+    pub queue_depth: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RollupBalance {
+    pub address: String,
+    pub pending_stroops: u64,
+    pub confirmed_stroops: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SettledIntent {
+    pub intent_id: String,
+    pub donor: String,
+    pub project_id: u64,
+    pub amount_stroops: u64,
+    pub nonce: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RollupBatch {
+    pub batch_id: u64,
+    pub settled_at_unix: u64,
+    pub intent_count: usize,
+    pub total_amount_stroops: u64,
+    pub state_root: String,
+    pub soroban_batch_tx: String,
+    pub intents: Vec<SettledIntent>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggerSettlementResponse {
+    pub settled: bool,
+    pub batch: Option<RollupBatch>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}
+
+#[derive(Debug, Clone)]
+struct StoredIntent {
+    intent_id: String,
+    donor: String,
+    project_id: u64,
+    amount_stroops: u64,
+    nonce: u64,
+}
+
+#[derive(Default)]
+struct RollupLedger {
+    queue: Vec<StoredIntent>,
+    pending_by_donor: HashMap<String, u64>,
+    confirmed_by_donor: HashMap<String, u64>,
+    last_nonce_by_donor: HashMap<String, u64>,
+    batches: Vec<RollupBatch>,
+    next_batch_id: u64,
+}
+
+pub struct RollupState {
+    ledger: Mutex<RollupLedger>,
+    pub settle_interval: Duration,
+}
+
+pub fn router(state: Arc<RollupState>) -> Router {
+    Router::new()
+        .route("/rollup/intents", post(submit_intent))
+    .route("/rollup/balance/{address}", get(get_balance))
+        .route("/rollup/batches", get(get_batches))
+        .route("/rollup/settle", post(settle_now))
+        .with_state(state)
+}
+
+async fn submit_intent(
+    State(state): State<Arc<RollupState>>,
+    Json(req): Json<SubmitIntentRequest>,
+) -> Result<Json<SubmitIntentResponse>, (StatusCode, Json<ErrorResponse>)> {
+    match state.submit(req) {
+        Ok(response) => Ok(Json(response)),
+        Err(message) => Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse { error: message }),
+        )),
+    }
+}
+
+async fn get_balance(
+    State(state): State<Arc<RollupState>>,
+    Path(address): Path<String>,
+) -> Json<RollupBalance> {
+    Json(state.balance_for(&address))
+}
+
+async fn get_batches(State(state): State<Arc<RollupState>>) -> Json<Vec<RollupBatch>> {
+    Json(state.batches())
+}
+
+async fn settle_now(State(state): State<Arc<RollupState>>) -> Json<TriggerSettlementResponse> {
+    let batch = state.settle_pending();
+    Json(TriggerSettlementResponse {
+        settled: batch.is_some(),
+        batch,
+    })
+}
+
+impl RollupState {
+    pub fn new(settle_interval: Duration) -> Self {
+        Self {
+            ledger: Mutex::new(RollupLedger {
+                next_batch_id: 1,
+                ..RollupLedger::default()
+            }),
+            settle_interval,
+        }
+    }
+
+    pub fn start_settlement_loop(self: Arc<Self>) {
+        let interval_duration = self.settle_interval;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval_duration);
+            loop {
+                ticker.tick().await;
+                let _ = self.settle_pending();
+            }
+        });
+    }
+
+    fn submit(&self, req: SubmitIntentRequest) -> Result<SubmitIntentResponse, String> {
+        validate_intent(&req)?;
+
+        let canonical = canonical_intent_message(
+            &req.domain,
+            &req.chain_id,
+            &req.donor,
+            req.project_id,
+            req.amount_stroops,
+            req.nonce,
+            req.expires_at,
+        );
+
+        if req.message != canonical {
+            return Err("Typed message does not match payload".to_string());
+        }
+
+        verify_signature(&req.public_key, &req.signature, canonical.as_bytes())?;
+        let intent_id = compute_intent_id(&req.message, &req.signature);
+
+        let mut guard = self.ledger.lock().unwrap();
+        let last_nonce = guard
+            .last_nonce_by_donor
+            .get(&req.donor)
+            .copied()
+            .unwrap_or_default();
+
+        if req.nonce <= last_nonce {
+            return Err("Nonce must strictly increase per donor".to_string());
+        }
+
+        guard
+            .last_nonce_by_donor
+            .insert(req.donor.clone(), req.nonce);
+
+        let pending_balance_stroops = {
+            let pending_balance = guard.pending_by_donor.entry(req.donor.clone()).or_insert(0);
+            *pending_balance = pending_balance.saturating_add(req.amount_stroops);
+            *pending_balance
+        };
+
+        guard.queue.push(StoredIntent {
+            intent_id: intent_id.clone(),
+            donor: req.donor.clone(),
+            project_id: req.project_id,
+            amount_stroops: req.amount_stroops,
+            nonce: req.nonce,
+        });
+
+        Ok(SubmitIntentResponse {
+            accepted: true,
+            intent_id,
+            pending_balance_stroops,
+            queue_depth: guard.queue.len(),
+        })
+    }
+
+    fn settle_pending(&self) -> Option<RollupBatch> {
+        let mut guard = self.ledger.lock().unwrap();
+        if guard.queue.is_empty() {
+            return None;
+        }
+
+        let batch_id = guard.next_batch_id;
+        guard.next_batch_id = guard.next_batch_id.saturating_add(1);
+
+        let settled_at_unix = now_unix();
+        let mut total_amount_stroops = 0u64;
+        let queue = std::mem::take(&mut guard.queue);
+
+        let mut settled_intents = Vec::with_capacity(queue.len());
+        let mut root_hasher = Sha256::new();
+
+        for intent in queue {
+            total_amount_stroops = total_amount_stroops.saturating_add(intent.amount_stroops);
+            root_hasher.update(intent.intent_id.as_bytes());
+
+            let pending = guard
+                .pending_by_donor
+                .entry(intent.donor.clone())
+                .or_insert(0);
+            *pending = pending.saturating_sub(intent.amount_stroops);
+
+            let confirmed = guard
+                .confirmed_by_donor
+                .entry(intent.donor.clone())
+                .or_insert(0);
+            *confirmed = confirmed.saturating_add(intent.amount_stroops);
+
+            settled_intents.push(SettledIntent {
+                intent_id: intent.intent_id,
+                donor: intent.donor,
+                project_id: intent.project_id,
+                amount_stroops: intent.amount_stroops,
+                nonce: intent.nonce,
+            });
+        }
+
+        let state_root = hex::encode(root_hasher.finalize());
+        let soroban_batch_tx = format!(
+            "soroban://batch_settle?batch_id={batch_id}&intents={}&state_root={state_root}",
+            settled_intents.len()
+        );
+
+        let batch = RollupBatch {
+            batch_id,
+            settled_at_unix,
+            intent_count: settled_intents.len(),
+            total_amount_stroops,
+            state_root,
+            soroban_batch_tx,
+            intents: settled_intents,
+        };
+
+        guard.batches.push(batch.clone());
+        Some(batch)
+    }
+
+    fn balance_for(&self, address: &str) -> RollupBalance {
+        let guard = self.ledger.lock().unwrap();
+        RollupBalance {
+            address: address.to_string(),
+            pending_stroops: guard.pending_by_donor.get(address).copied().unwrap_or(0),
+            confirmed_stroops: guard.confirmed_by_donor.get(address).copied().unwrap_or(0),
+        }
+    }
+
+    fn batches(&self) -> Vec<RollupBatch> {
+        let guard = self.ledger.lock().unwrap();
+        guard.batches.clone()
+    }
+}
+
+fn validate_intent(req: &SubmitIntentRequest) -> Result<(), String> {
+    if req.domain.trim().is_empty() {
+        return Err("domain is required".to_string());
+    }
+    if req.chain_id.trim().is_empty() {
+        return Err("chain_id is required".to_string());
+    }
+    if req.donor.trim().is_empty() {
+        return Err("donor is required".to_string());
+    }
+    if req.amount_stroops == 0 {
+        return Err("amount_stroops must be greater than zero".to_string());
+    }
+
+    if req.expires_at <= now_unix() {
+        return Err("intent has expired".to_string());
+    }
+
+    Ok(())
+}
+
+pub fn canonical_intent_message(
+    domain: &str,
+    chain_id: &str,
+    donor: &str,
+    project_id: u64,
+    amount_stroops: u64,
+    nonce: u64,
+    expires_at: u64,
+) -> String {
+    format!(
+        "PIFP_ROLLUP_INTENT\n\\
+        domain:{domain}\n\\
+        chain_id:{chain_id}\n\\
+        donor:{donor}\n\\
+        project_id:{project_id}\n\\
+        amount_stroops:{amount_stroops}\n\\
+        nonce:{nonce}\n\\
+        expires_at:{expires_at}"
+    )
+}
+
+fn verify_signature(public_key_b64: &str, signature_b64: &str, message: &[u8]) -> Result<(), String> {
+    let public_key_bytes = BASE64
+        .decode(public_key_b64)
+        .map_err(|_| "public_key is not valid base64".to_string())?;
+    let signature_bytes = BASE64
+        .decode(signature_b64)
+        .map_err(|_| "signature is not valid base64".to_string())?;
+
+    let public_key_arr: [u8; 32] = public_key_bytes
+        .try_into()
+        .map_err(|_| "public_key must decode to 32 bytes".to_string())?;
+    let signature_arr: [u8; 64] = signature_bytes
+        .try_into()
+        .map_err(|_| "signature must decode to 64 bytes".to_string())?;
+
+    let key = VerifyingKey::from_bytes(&public_key_arr)
+        .map_err(|_| "invalid ed25519 public key".to_string())?;
+    let signature = Signature::from_bytes(&signature_arr);
+
+    key.verify(message, &signature)
+        .map_err(|_| "signature verification failed".to_string())
+}
+
+fn compute_intent_id(message: &str, signature_b64: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(message.as_bytes());
+    hasher.update(signature_b64.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn build_signed_request(amount_stroops: u64, nonce: u64) -> SubmitIntentRequest {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let public_key = signing_key.verifying_key();
+
+        let expires_at = now_unix() + 120;
+        let message = canonical_intent_message(
+            "pifp-rollup-v1",
+            "soroban-testnet",
+            "GABC123DONOR",
+            42,
+            amount_stroops,
+            nonce,
+            expires_at,
+        );
+
+        let signature = signing_key.sign(message.as_bytes());
+
+        SubmitIntentRequest {
+            domain: "pifp-rollup-v1".to_string(),
+            chain_id: "soroban-testnet".to_string(),
+            donor: "GABC123DONOR".to_string(),
+            project_id: 42,
+            amount_stroops,
+            nonce,
+            expires_at,
+            message,
+            signature: BASE64.encode(signature.to_bytes()),
+            public_key: BASE64.encode(public_key.to_bytes()),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_signed_intent_and_tracks_pending_balance() {
+        let state = RollupState::new(Duration::from_secs(30));
+        let req = build_signed_request(10_000, 1);
+
+        let response = state.submit(req).expect("request should succeed");
+        assert!(response.accepted);
+        assert_eq!(response.pending_balance_stroops, 10_000);
+        assert_eq!(response.queue_depth, 1);
+
+        let balance = state.balance_for("GABC123DONOR");
+        assert_eq!(balance.pending_stroops, 10_000);
+        assert_eq!(balance.confirmed_stroops, 0);
+    }
+
+    #[test]
+    fn rejects_invalid_signature() {
+        let state = RollupState::new(Duration::from_secs(30));
+        let mut req = build_signed_request(10_000, 1);
+        req.signature = BASE64.encode([0u8; 64]);
+
+        let error = state.submit(req).expect_err("signature should fail");
+        assert!(error.contains("verification"));
+    }
+
+    #[test]
+    fn settlement_moves_pending_to_confirmed() {
+        let state = RollupState::new(Duration::from_secs(30));
+        state
+            .submit(build_signed_request(5_000, 1))
+            .expect("first intent should succeed");
+        state
+            .submit(build_signed_request(7_000, 2))
+            .expect("second intent should succeed");
+
+        let batch = state
+            .settle_pending()
+            .expect("batch should be created with pending intents");
+        assert_eq!(batch.intent_count, 2);
+        assert_eq!(batch.total_amount_stroops, 12_000);
+
+        let balance = state.balance_for("GABC123DONOR");
+        assert_eq!(balance.pending_stroops, 0);
+        assert_eq!(balance.confirmed_stroops, 12_000);
+    }
+}

--- a/backend/oracle/src/verifier.rs
+++ b/backend/oracle/src/verifier.rs
@@ -149,6 +149,9 @@ mod tests {
             network_passphrase: String::new(),
             sentry_dsn: None,
             metrics_port: 9090,
+            foreign_rpc_url: None,
+            foreign_bridge_address: None,
+            node_id: 1,
         };
 
         // Use a CID that definitely doesn't exist

--- a/backend/oracle/src/verifier.rs
+++ b/backend/oracle/src/verifier.rs
@@ -152,6 +152,14 @@ mod tests {
             foreign_rpc_url: None,
             foreign_bridge_address: None,
             node_id: 1,
+            oracle_asset_symbol: "XLM".to_string(),
+            oracle_quote_symbol: "USD".to_string(),
+            oracle_refresh_secs: 15,
+            oracle_max_staleness_secs: 90,
+            oracle_max_variance_pct: 5.0,
+            oracle_coingecko_url: String::new(),
+            oracle_binance_url: String::new(),
+            oracle_kraken_url: String::new(),
         };
 
         // Use a CID that definitely doesn't exist

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 import { BridgeWatcher } from './components/BridgeWatcher'
 import { IpfsUploader } from './components/IpfsUploader'
+import { OracleStatusBanner, useOracleStatus } from './components/OracleStatusBanner'
 
 const API_BASE = (import.meta.env.VITE_INDEXER_API_URL || 'http://localhost:8080').replace(/\/$/, '')
 
@@ -30,6 +31,9 @@ function App() {
   const [projects, setProjects] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
+  const [oracleModalOpen, setOracleModalOpen] = useState(false)
+
+  const { oracleStatus, oracleBlocking } = useOracleStatus()
 
   const [status, setStatus] = useState('all')
   const [creator, setCreator] = useState('')
@@ -91,6 +95,25 @@ function App() {
 
   return (
     <main className="app-container">
+      <OracleStatusBanner
+        showModal={oracleModalOpen}
+        onModalClose={() => setOracleModalOpen((o) => !o)}
+      />
+
+      {oracleBlocking && (
+        <div className="oracle-blocking-notice" role="alert">
+          <strong>Oracle protection active:</strong>{' '}
+          {oracleStatus?.summary || 'Oracle data is stale or has high variance.'}{' '}
+          Critical protocol actions are disabled until the oracle recovers.
+          <button
+            className="oracle-detail-btn"
+            onClick={() => setOracleModalOpen(true)}
+          >
+            View details
+          </button>
+        </div>
+      )}
+
       <nav className="main-nav">
         <button 
           className={activeTab === 'dashboard' ? 'active' : ''} 

--- a/frontend/src/components/L2Wallet.jsx
+++ b/frontend/src/components/L2Wallet.jsx
@@ -1,0 +1,266 @@
+import { useMemo, useState } from 'react'
+
+const ORACLE_API = (import.meta.env.VITE_ORACLE_API_URL || 'http://localhost:9090/api').replace(/\/$/, '')
+const DEFAULT_CHAIN = import.meta.env.VITE_ROLLUP_CHAIN_ID || 'soroban-testnet'
+const DEFAULT_DOMAIN = 'pifp-rollup-v1'
+
+function encodeBase64(bytes) {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return window.btoa(binary)
+}
+
+function canonicalIntentMessage({ donor, projectId, amountStroops, nonce, expiresAt }) {
+  return [
+    'PIFP_ROLLUP_INTENT',
+    `domain:${DEFAULT_DOMAIN}`,
+    `chain_id:${DEFAULT_CHAIN}`,
+    `donor:${donor}`,
+    `project_id:${projectId}`,
+    `amount_stroops:${amountStroops}`,
+    `nonce:${nonce}`,
+    `expires_at:${expiresAt}`,
+  ].join('\n')
+}
+
+export function L2Wallet() {
+  const [l2Mode, setL2Mode] = useState(true)
+  const [donor, setDonor] = useState('G-L2-EXAMPLE-ADDRESS')
+  const [projectId, setProjectId] = useState('1')
+  const [amount, setAmount] = useState('0.01')
+  const [nonce, setNonce] = useState('1')
+  const [expiresInSeconds, setExpiresInSeconds] = useState('300')
+  const [wallet, setWallet] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  const [lastIntent, setLastIntent] = useState('')
+  const [balance, setBalance] = useState({ pending_stroops: 0, confirmed_stroops: 0 })
+
+  const amountStroops = useMemo(() => {
+    const parsed = Number.parseFloat(amount)
+    if (!Number.isFinite(parsed) || parsed <= 0) return 0
+    return Math.floor(parsed * 10_000_000)
+  }, [amount])
+
+  async function ensureWallet() {
+    if (wallet) return wallet
+
+    if (!window.crypto?.subtle) {
+      throw new Error('WebCrypto is required for L2 signing in this browser')
+    }
+
+    const keyPair = await window.crypto.subtle.generateKey(
+      {
+        name: 'Ed25519',
+      },
+      true,
+      ['sign', 'verify'],
+    )
+
+    const rawPub = await window.crypto.subtle.exportKey('raw', keyPair.publicKey)
+    const exportedPubKey = encodeBase64(new Uint8Array(rawPub))
+    const newWallet = {
+      publicKey: exportedPubKey,
+      sign: async (messageText) => {
+        const signature = await window.crypto.subtle.sign(
+          { name: 'Ed25519' },
+          keyPair.privateKey,
+          new TextEncoder().encode(messageText),
+        )
+        return encodeBase64(new Uint8Array(signature))
+      },
+    }
+
+    setWallet(newWallet)
+    return newWallet
+  }
+
+  async function refreshBalance(address) {
+    const response = await fetch(`${ORACLE_API}/rollup/balance/${encodeURIComponent(address)}`)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch L2 balance (${response.status})`)
+    }
+    const payload = await response.json()
+    setBalance(payload)
+  }
+
+  async function submitL2Intent() {
+    setError('')
+    setBusy(true)
+
+    try {
+      if (!l2Mode) {
+        throw new Error('Enable L2 Wallet mode to submit off-chain intent')
+      }
+      if (!donor.trim()) {
+        throw new Error('Donor address is required')
+      }
+      if (!Number.isInteger(Number(projectId)) || Number(projectId) <= 0) {
+        throw new Error('Project ID must be a positive integer')
+      }
+      if (amountStroops <= 0) {
+        throw new Error('Amount must be greater than zero')
+      }
+
+      const walletHandle = await ensureWallet()
+      const now = Math.floor(Date.now() / 1000)
+      const expiresAt = now + Math.max(30, Number.parseInt(expiresInSeconds, 10) || 300)
+
+      const message = canonicalIntentMessage({
+        donor: donor.trim(),
+        projectId: Number(projectId),
+        amountStroops,
+        nonce: Number(nonce),
+        expiresAt,
+      })
+
+      const signature = await walletHandle.sign(message)
+
+      const response = await fetch(`${ORACLE_API}/rollup/intents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          domain: DEFAULT_DOMAIN,
+          chain_id: DEFAULT_CHAIN,
+          donor: donor.trim(),
+          project_id: Number(projectId),
+          amount_stroops: amountStroops,
+          nonce: Number(nonce),
+          expires_at: expiresAt,
+          message,
+          signature,
+          public_key: walletHandle.publicKey,
+        }),
+      })
+
+      const payload = await response.json()
+      if (!response.ok) {
+        throw new Error(payload.error || `Oracle returned ${response.status}`)
+      }
+
+      setLastIntent(payload.intent_id)
+      await refreshBalance(donor.trim())
+      setNonce((current) => String(Number(current) + 1))
+    } catch (err) {
+      setError(err.message || 'Failed to submit L2 intent')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function settleBatch() {
+    setBusy(true)
+    setError('')
+    try {
+      const response = await fetch(`${ORACLE_API}/rollup/settle`, { method: 'POST' })
+      if (!response.ok) {
+        throw new Error(`Settlement failed (${response.status})`)
+      }
+      await refreshBalance(donor.trim())
+    } catch (err) {
+      setError(err.message || 'Failed to settle rollup batch')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <section className="l2-wallet" aria-live="polite">
+      <header className="page-header">
+        <h2>L2 Wallet Micro-Rollup</h2>
+        <p>
+          Sign off-chain authorization messages for micro-donations, queue them in the Rust sequencer,
+          and settle them in periodic Soroban batches.
+        </p>
+      </header>
+
+      <div className="l2-grid">
+        <div className="card">
+          <label className="toggle-row">
+            <input
+              type="checkbox"
+              checked={l2Mode}
+              onChange={(e) => setL2Mode(e.target.checked)}
+            />
+            <span>Enable L2 Wallet mode (off-chain signatures)</span>
+          </label>
+
+          <label>
+            <span>Donor Address</span>
+            <input value={donor} onChange={(e) => setDonor(e.target.value)} />
+          </label>
+
+          <div className="inline-grid">
+            <label>
+              <span>Project ID</span>
+              <input value={projectId} onChange={(e) => setProjectId(e.target.value)} />
+            </label>
+            <label>
+              <span>Amount (XLM)</span>
+              <input value={amount} onChange={(e) => setAmount(e.target.value)} />
+            </label>
+          </div>
+
+          <div className="inline-grid">
+            <label>
+              <span>Nonce</span>
+              <input value={nonce} onChange={(e) => setNonce(e.target.value)} />
+            </label>
+            <label>
+              <span>TTL (seconds)</span>
+              <input value={expiresInSeconds} onChange={(e) => setExpiresInSeconds(e.target.value)} />
+            </label>
+          </div>
+
+          <div className="actions-row">
+            <button type="button" onClick={submitL2Intent} disabled={busy}>
+              {busy ? 'Submitting...' : 'Sign Off-Chain Authorization'}
+            </button>
+            <button type="button" onClick={settleBatch} disabled={busy} className="ghost-btn">
+              Settle Current Batch
+            </button>
+          </div>
+
+          {error && <p className="error">{error}</p>}
+          {lastIntent && (
+            <p className="meta">
+              Last intent ID: <code>{lastIntent.slice(0, 20)}...</code>
+            </p>
+          )}
+        </div>
+
+        <div className="card balances-card">
+          <h3>Rollup Balance View</h3>
+          <p className="meta">Comparing off-chain pending and on-chain-confirmed totals.</p>
+          <div className="balance-row">
+            <span>Pending (L2 queue)</span>
+            <strong>{balance.pending_stroops} stroops</strong>
+          </div>
+          <div className="balance-row">
+            <span>Confirmed (on-chain)</span>
+            <strong>{balance.confirmed_stroops} stroops</strong>
+          </div>
+
+          <div className="typed-preview">
+            <h4>Typed Data Preview</h4>
+            <pre>
+              {canonicalIntentMessage({
+                donor: donor.trim() || '<donor>',
+                projectId: Number(projectId) || 0,
+                amountStroops,
+                nonce: Number(nonce) || 0,
+                expiresAt: Math.floor(Date.now() / 1000) + (Number(expiresInSeconds) || 300),
+              })}
+            </pre>
+          </div>
+
+          {wallet?.publicKey && (
+            <p className="meta">Session public key: <code>{wallet.publicKey.slice(0, 24)}...</code></p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/OracleStatusBanner.jsx
+++ b/frontend/src/components/OracleStatusBanner.jsx
@@ -1,0 +1,255 @@
+/**
+ * OracleStatusBanner – fetches /oracle/quote and renders a health indicator.
+ *
+ * Green  (health_score >= 80): all clear, protocol actions enabled.
+ * Yellow (health_score 55-79): degraded, advisory warning shown.
+ * Red    (health_score  < 55): critical / stale / high-variance; disable critical actions + modal.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+const ORACLE_BASE = (
+  import.meta.env.VITE_ORACLE_API_URL || 'http://localhost:9090'
+).replace(/\/$/, '')
+
+const POLL_INTERVAL_MS = 15_000
+
+/**
+ * React hook that polls the oracle /oracle/quote endpoint.
+ * @returns {{ oracleStatus: object|null, oracleBlocking: boolean, refreshOracle: function }}
+ */
+export function useOracleStatus() {
+  const [oracleStatus, setOracleStatus] = useState(null)
+  const abortRef = useRef(null)
+
+  const fetchStatus = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const res = await fetch(`${ORACLE_BASE}/oracle/quote`, {
+        signal: controller.signal,
+      })
+      if (!res.ok) throw new Error(`Oracle API returned ${res.status}`)
+      const data = await res.json()
+      setOracleStatus(data)
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        setOracleStatus((prev) =>
+          prev
+            ? { ...prev, _fetchError: err.message }
+            : {
+                indicator: 'red',
+                status: 'critical',
+                health_score: 0,
+                stale: true,
+                high_variance: false,
+                summary: 'Oracle service unreachable.',
+                reasons: [err.message],
+                recovery_actions: [],
+                providers: [],
+              }
+        )
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchStatus()
+    const timer = setInterval(fetchStatus, POLL_INTERVAL_MS)
+    return () => {
+      clearInterval(timer)
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchStatus])
+
+  const oracleBlocking =
+    oracleStatus !== null &&
+    (oracleStatus.stale || oracleStatus.high_variance || oracleStatus.indicator === 'red')
+
+  return { oracleStatus, oracleBlocking, refreshOracle: fetchStatus }
+}
+
+/**
+ * Renders the oracle status pill, price info, and (when degraded/critical) a details modal.
+ *
+ * @param {{ showModal: boolean, onModalClose: function }} props
+ */
+export function OracleStatusBanner({ showModal, onModalClose }) {
+  const { oracleStatus, oracleBlocking, refreshOracle } = useOracleStatus()
+
+  if (!oracleStatus) {
+    return (
+      <div className="oracle-banner oracle-banner--loading" role="status" aria-live="polite">
+        <span className="oracle-pill oracle-pill--loading" aria-label="Oracle loading">⏳</span>
+        <span>Checking oracle feed…</span>
+      </div>
+    )
+  }
+
+  const {
+    indicator,
+    status,
+    health_score,
+    aggregated_price,
+    quote_symbol,
+    asset_symbol,
+    variance_pct,
+    max_sample_age_secs,
+    summary,
+    reasons,
+    recovery_actions,
+    providers,
+  } = oracleStatus
+
+  const pillLabel = { green: '● Healthy', yellow: '● Degraded', red: '● Critical' }[indicator] ?? '● Unknown'
+
+  return (
+    <>
+      <div
+        className={`oracle-banner oracle-banner--${indicator}`}
+        role="status"
+        aria-live="polite"
+        aria-label={`Oracle status: ${status}`}
+      >
+        <span
+          className={`oracle-pill oracle-pill--${indicator}`}
+          title={`Health score: ${health_score}/100`}
+        >
+          {pillLabel}
+        </span>
+
+        {aggregated_price != null ? (
+          <span className="oracle-price">
+            {asset_symbol}/{quote_symbol}: <strong>${aggregated_price}</strong>
+          </span>
+        ) : (
+          <span className="oracle-price oracle-price--unavailable">Price unavailable</span>
+        )}
+
+        <span className="oracle-meta">
+          Age: {max_sample_age_secs}s · Variance: {variance_pct}%
+        </span>
+
+        {indicator !== 'green' && (
+          <button
+            className="oracle-detail-btn"
+            onClick={onModalClose}
+            aria-expanded={showModal}
+            aria-controls="oracle-detail-modal"
+          >
+            {showModal ? 'Hide details' : 'View details'}
+          </button>
+        )}
+
+        <button
+          className="oracle-refresh-btn"
+          onClick={refreshOracle}
+          aria-label="Refresh oracle feed"
+          title="Refresh now"
+        >
+          ↻
+        </button>
+      </div>
+
+      {showModal && indicator !== 'green' && (
+        <div
+          id="oracle-detail-modal"
+          className={`oracle-modal oracle-modal--${indicator}`}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Oracle status details"
+        >
+          <div className="oracle-modal__backdrop" onClick={onModalClose} aria-hidden="true" />
+          <div className="oracle-modal__content">
+            <button
+              className="oracle-modal__close"
+              onClick={onModalClose}
+              aria-label="Close oracle details"
+            >
+              ✕
+            </button>
+
+            <h2 className="oracle-modal__title">
+              <span className={`oracle-pill oracle-pill--${indicator}`}>{pillLabel}</span>
+              Oracle {status.charAt(0).toUpperCase() + status.slice(1)}
+            </h2>
+
+            <p className="oracle-modal__summary">{summary}</p>
+
+            {oracleBlocking && (
+              <div className="oracle-modal__block-notice" role="alert">
+                <strong>Protocol actions are paused</strong> while the oracle is in this state.
+                Critical actions will remain disabled until the indicator returns to green.
+              </div>
+            )}
+
+            {reasons.length > 0 && (
+              <section className="oracle-modal__section">
+                <h3>Reasons</h3>
+                <ul>
+                  {reasons.map((r, i) => (
+                    <li key={i}>{r}</li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            {recovery_actions.length > 0 && (
+              <section className="oracle-modal__section">
+                <h3>Recovery actions</h3>
+                <ol>
+                  {recovery_actions.map((a, i) => (
+                    <li key={i}>{a}</li>
+                  ))}
+                </ol>
+              </section>
+            )}
+
+            {providers.length > 0 && (
+              <section className="oracle-modal__section oracle-modal__providers">
+                <h3>Provider observations</h3>
+                <table aria-label="Provider observations">
+                  <thead>
+                    <tr>
+                      <th>Provider</th>
+                      <th>Price</th>
+                      <th>Age (s)</th>
+                      <th>Status</th>
+                      <th>Detail</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {providers.map((p) => (
+                      <tr key={p.provider}>
+                        <td>{p.provider}</td>
+                        <td>{p.price != null ? `$${p.price}` : '—'}</td>
+                        <td>{p.age_secs}</td>
+                        <td>
+                          <span className={`oracle-provider-badge oracle-provider-badge--${p.status}`}>
+                            {p.status}
+                          </span>
+                        </td>
+                        <td className="oracle-provider-detail">{p.detail}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            )}
+
+            <div className="oracle-modal__footer">
+              <button className="oracle-modal__close-btn" onClick={onModalClose}>
+                Close
+              </button>
+              <button className="oracle-refresh-btn" onClick={refreshOracle}>
+                ↻ Refresh now
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
Closes #222  ## Changes  ### Backend (Rust) - **ackend/oracle/src/oracle_api.rs** (new): OracleApiState with concurrent 	okio::join! fetching from CoinGecko, Binance, and Kraken simultaneously - **Medianizer algorithm**: sorts provider prices, computes median, rejects samples >5% relative deviation, recomputes final median from accepted samples only - **Health score (0-100)**: penalises staleness and high variance; >=80 green/healthy, 55-79 yellow/degraded, <55 red/critical - **GET /oracle/quote** endpoint returning OracleSnapshotResponse with price, indicator, stale, high_variance, age_secs, variance_pct, and per-provider observations - **ackend/oracle/src/config.rs**: 9 new oracle config fields - **ackend/oracle/src/health.rs**: merges oracle router into the axum app - **ackend/oracle/src/main.rs**: instantiates OracleApiState and passes to health::serve - **ackend/oracle/src/verifier.rs**: updated test fixture with new config fields  ### Frontend (React) - **rontend/src/components/OracleStatusBanner.jsx** (new): useOracleStatus() hook polling /oracle/quote every 15s; OracleStatusBanner with green/yellow/red indicator pill, price, age, variance, detail modal with provider table and recovery actions - **rontend/src/App.jsx**: banner + blocking notice when oracleBlocking (stale or high_variance or red) - **rontend/src/App.css**: oracle banner and modal styles  ### Tests 14 unit tests all pass: parsers (CoinGecko/Binance/Kraken), medianizer outlier rejection, staleness/variance flagging, missing/zero-price red indicator, full mock refresh via mockito